### PR TITLE
Replace deprecated Box components in profile forms

### DIFF
--- a/src/components/profile/MyProfileForm.tsx
+++ b/src/components/profile/MyProfileForm.tsx
@@ -1,6 +1,6 @@
 "use client";
-import { Box, Button, FormControl, TextInput, Textarea, Checkbox } from "@primer/react";
-import { useEffect, useState } from "react";
+import { Button, FormControl, TextInput, Textarea, Checkbox } from "@primer/react";
+import { useEffect, useState, type FormEvent } from "react";
 import type { ProfileOwnerDto, ProfileUpdateRequest } from "@/src/lib/types/profile";
 import { useUpdateMyProfile } from "@/src/lib/queries/profile";
 
@@ -26,7 +26,7 @@ export function MyProfileForm({ me }: { me: ProfileOwnerDto }) {
   ) => setForm((s) => ({ ...s, [k]: v }));
 
   return (
-    <Box as="form" sx={{ display: "grid", gap: 3 }} onSubmit={(e) => { e.preventDefault(); m.mutate(form); }}>
+    <form style={{ display: "grid", gap: 16 }} onSubmit={(e: FormEvent<HTMLFormElement>) => { e.preventDefault(); m.mutate(form); }}>
       <FormControl>
         <FormControl.Label>Display name</FormControl.Label>
         <TextInput value={form.displayName ?? ""} onChange={(e) => onChange("displayName", e.target.value)} />
@@ -47,12 +47,16 @@ export function MyProfileForm({ me }: { me: ProfileOwnerDto }) {
         <FormControl.Label>Language</FormControl.Label>
         <TextInput value={form.language ?? ""} onChange={(e) => onChange("language", e.target.value)} />
       </FormControl>
-      <Checkbox
-        checked={!!form.isPublic}
-        onChange={(e) => onChange("isPublic", e.target.checked)}
-      >Public profile</Checkbox>
+      <FormControl>
+        <Checkbox
+          id="isPublic"
+          checked={!!form.isPublic}
+          onChange={(e) => onChange("isPublic", e.target.checked)}
+        />
+        <FormControl.Label htmlFor="isPublic">Public profile</FormControl.Label>
+      </FormControl>
 
       <Button type="submit" variant="primary" loading={m.isPending}>Save changes</Button>
-    </Box>
+    </form>
   );
 }

--- a/src/components/profile/MyProfileHeader.tsx
+++ b/src/components/profile/MyProfileHeader.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { Box, Avatar, Button, Text, Label, TextInput } from "@primer/react";
+import { Avatar, Button, Text, Label, TextInput } from "@primer/react";
 import { useState } from "react";
 import { useUpdateMyAvatar, useUpdateMyBanner } from "@/src/lib/queries/profile";
 
@@ -16,42 +16,41 @@ export function MyProfileHeader(props: {
   const mBanner = useUpdateMyBanner();
 
   return (
-    <Box sx={{ display: "grid", gap: 3 }}>
-      <Box
-        sx={{
+    <div style={{ display: "grid", gap: 16 }}>
+      <div
+        style={{
           height: 160,
           borderRadius: 12,
           background: `center/cover no-repeat url(${props.bannerUrl ?? "/banner-placeholder.jpg"})`,
-          border: "1px solid",
-          borderColor: "border.default",
+          border: "1px solid var(--borderColor-default)",
         }}
       />
-      <Box sx={{ display: "flex", alignItems: "center", gap: 3 }}>
+      <div style={{ display: "flex", alignItems: "center", gap: 16 }}>
         <Avatar src={props.avatarUrl ?? ""} alt={props.username} size={72} square />
-        <Box sx={{ display: "grid" }}>
+        <div style={{ display: "grid" }}>
           <Text as="h2" sx={{ m: 0, fontWeight: 600 }}>
             {props.displayName ?? props.username} {props.isVerified && <Label variant="success">Verified</Label>}
           </Text>
           <Text sx={{ color: "fg.muted" }}>@{props.username}</Text>
-        </Box>
-      </Box>
+        </div>
+      </div>
 
-      <Box sx={{ display: "grid", gap: 2 }}>
-        <Box sx={{ display: "flex", gap: 2 }}>
+      <div style={{ display: "grid", gap: 8 }}>
+        <div style={{ display: "flex", gap: 8 }}>
           <TextInput placeholder="Avatar URL" value={avatar} onChange={(e) => setAvatar(e.target.value)} />
           <Button
             onClick={() => mAvatar.mutate({ avatarUrl: avatar })}
             loading={mAvatar.isPending}
           >Save avatar</Button>
-        </Box>
-        <Box sx={{ display: "flex", gap: 2 }}>
+        </div>
+        <div style={{ display: "flex", gap: 8 }}>
           <TextInput placeholder="Banner URL" value={banner} onChange={(e) => setBanner(e.target.value)} />
           <Button
             onClick={() => mBanner.mutate({ bannerUrl: banner })}
             loading={mBanner.isPending}
           >Save banner</Button>
-        </Box>
-      </Box>
-    </Box>
+        </div>
+      </div>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- replace deprecated `Box` components with semantic elements
- fix checkbox runtime error in profile form
- add typed submit handler and remove `any` warning

## Testing
- `npm run lint`
- `npm run build` *(fails: Module not found: Can't resolve '@/src/lib/queries/profile')*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b350d47b50832e80360f25e4f8f5bc