### PR TITLE
feat: add listing pages and filters

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,13 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+    images: {
+        remotePatterns: [
+            { protocol: "http", hostname: "localhost", port: "8080", pathname: "/uploads/**" },
+            { protocol: "https", hostname: "picsum.photos" },
+            { protocol: "https", hostname: "example.com" },
+        ],
+    },
 };
 
 export default nextConfig;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -24,3 +24,7 @@ body {
   color: var(--foreground);
   font-family: Arial, Helvetica, sans-serif;
 }
+
+.input {
+  @apply w-full rounded-lg border border-white/15 bg-transparent px-3 py-2 text-sm;
+}

--- a/src/app/listings/[id]/page.tsx
+++ b/src/app/listings/[id]/page.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import { useParams } from "next/navigation";
+import { useListingById } from "@/lib/queries/listings";
+
+export default function ListingDetailPage() {
+    const params = useParams<{ id: string }>();
+    const id = Number(params.id);
+    const { data, isLoading, isError } = useListingById(id);
+
+    if (isLoading) return <main className="mx-auto max-w-[1100px] px-4 py-6">Yükleniyor…</main>;
+    if (isError || !data) return <main className="mx-auto max-w-[1100px] px-4 py-6">İlan bulunamadı.</main>;
+
+    const img = data.images?.[0]?.url ?? "/listing-placeholder.jpg";
+
+    return (
+        <main className="mx-auto max-w-[1100px] px-4 py-6">
+            <div className="grid gap-6 lg:grid-cols-[2fr,1fr]">
+                {/* Görsel + açıklama */}
+                <section className="rounded-xl border border-white/10 bg-neutral-900 p-4">
+                    <div className="aspect-[4/3] w-full overflow-hidden rounded-lg">
+                        {/* eslint-disable-next-line @next/next/no-img-element */}
+                        <img src={img} alt={data.title} className="h-full w-full object-cover" />
+                    </div>
+                    <h1 className="mt-4 text-2xl font-extrabold tracking-tight">{data.title}</h1>
+                    {data.description && <p className="mt-2 whitespace-pre-wrap text-sm text-neutral-300">{data.description}</p>}
+                </section>
+
+                {/* Özellikler & fiyat */}
+                <aside className="space-y-4">
+                    <div className="rounded-xl border border-white/10 bg-neutral-900 p-4">
+                        <div className="text-xl font-bold">
+                            {data.type === "TRADE" ? "Takas" : formatMoney(data.price, data.currency)}
+                        </div>
+                        {data.location && <div className="text-sm text-neutral-400 mt-1">{data.location}</div>}
+                        {data.seller && (
+                            <div className="mt-4 flex items-center gap-3">
+                                {/* eslint-disable-next-line @next/next/no-img-element */}
+                                <img src={data.seller.avatarUrl ?? "/avatar-placeholder.png"} alt="seller" className="h-10 w-10 rounded-lg object-cover" />
+                                <div>
+                                    <div className="font-semibold">{data.seller.displayName ?? data.seller.username ?? "Satıcı"}</div>
+                                    {data.seller.location && <div className="text-xs text-neutral-400">{data.seller.location}</div>}
+                                </div>
+                            </div>
+                        )}
+                        <button className="mt-4 w-full rounded-lg bg-gradient-to-r from-sky-400 to-blue-600 px-4 py-2 text-sm font-semibold text-white">
+                            {data.type === "TRADE" ? "Takas Teklifi Ver" : "Satıcıyla İletişime Geç"}
+                        </button>
+                    </div>
+
+                    <div className="rounded-xl border border-white/10 bg-neutral-900 p-4">
+                        <h3 className="mb-2 font-bold">Teknik Bilgiler</h3>
+                        <dl className="grid grid-cols-2 gap-x-4 gap-y-2 text-sm">
+                            <DT k="Marka" v={data.brandName} />
+                            <DT k="Seri" v={data.seriesName} />
+                            <DT k="Model" v={data.modelName} />
+                            <DT k="Ölçek" v={data.scale} />
+                            <DT k="Model Yılı" v={data.modelYear?.toString()} />
+                            <DT k="Durum" v={data.condition} />
+                            <DT k="Tema" v={data.theme} />
+                            <DT k="Menşei" v={data.countryOfOrigin} />
+                            <DT k="Durum (ilan)" v={data.status} />
+                            <DT k="Son Güncelleme" v={data.updatedAt?.slice(0,10)} />
+                        </dl>
+                    </div>
+
+                    {data.tags && data.tags.length > 0 && (
+                        <div className="rounded-xl border border-white/10 bg-neutral-900 p-4">
+                            <h3 className="mb-2 font-bold">Etiketler</h3>
+                            <div className="flex flex-wrap gap-2">
+                                {data.tags.map(t => (
+                                    <span key={t.id} className="rounded-md bg-white/10 px-2 py-0.5 text-xs">{t.name}</span>
+                                ))}
+                            </div>
+                        </div>
+                    )}
+                </aside>
+            </div>
+        </main>
+    );
+}
+
+function DT({ k, v }: { k: string; v?: string | null }) {
+    if (!v) return null;
+    return (
+        <>
+            <dt className="text-neutral-400">{k}</dt>
+            <dd className="font-medium">{v}</dd>
+        </>
+    );
+}
+
+function formatMoney(v: number | string | null | undefined, cur?: string | null) {
+    const n = typeof v === "string" ? Number(v) : v ?? 0;
+    return new Intl.NumberFormat("tr-TR", { style: "currency", currency: cur ?? "TRY", maximumFractionDigits: 0 }).format(n);
+}

--- a/src/app/listings/page.tsx
+++ b/src/app/listings/page.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { useListingsSearch, type ListingsSearchParams } from "@/lib/queries/listings";
+import ListingCard from "@/components/listings/ListingCard";
+import ListingFilters, { type Filters } from "@/components/listings/ListingFilters";
+
+export default function ListingsPage() {
+    const [params, setParams] = useState<ListingsSearchParams>({
+        page: 0, size: 24, sortBy: "createdAt", sortDir: "DESC",
+    });
+
+    const { data, isLoading, isError } = useListingsSearch(params);
+    const page = data?.number ?? 0;
+    const totalPages = data?.totalPages ?? 0;
+
+    const filters: Filters = useMemo(() => ({
+        type: params.type, priceMin: params.priceMin, priceMax: params.priceMax,
+        sortBy: params.sortBy, sortDir: params.sortDir, size: params.size
+    }), [params]);
+
+    return (
+        <main className="mx-auto w-full max-w-[1200px] px-4 py-6">
+            <h1 className="mb-4 text-2xl font-extrabold tracking-tight">İlanlar</h1>
+
+            <ListingFilters
+                value={filters}
+                onChange={(f) => setParams((s) => ({ ...s, ...f, page: 0 }))}
+            />
+
+            {isLoading && <div className="mt-6 text-neutral-400">Yükleniyor…</div>}
+            {isError && <div className="mt-6 text-rose-400">Bir hata oluştu.</div>}
+
+            <div className="mt-6 grid grid-cols-2 gap-4 md:grid-cols-3 lg:grid-cols-4">
+                {data?.content?.map((it) => <ListingCard key={it.id} it={it} />)}
+            </div>
+
+            {totalPages > 1 && (
+                <div className="mt-8 flex items-center justify-center gap-2">
+                    <button
+                        disabled={page <= 0}
+                        onClick={() => setParams((s) => ({ ...s, page: Math.max(0, (s.page ?? 0) - 1) }))}
+                        className="rounded-lg border border-white/15 px-3 py-1.5 text-sm disabled:opacity-50"
+                    >
+                        ← Önceki
+                    </button>
+                    <span className="text-sm text-neutral-400">
+                        Sayfa {page + 1} / {totalPages}
+                    </span>
+                    <button
+                        disabled={page + 1 >= totalPages}
+                        onClick={() => setParams((s) => ({ ...s, page: (s.page ?? 0) + 1 }))}
+                        className="rounded-lg border border-white/15 px-3 py-1.5 text-sm disabled:opacity-50"
+                    >
+                        Sonraki →
+                    </button>
+                </div>
+            )}
+        </main>
+    );
+}

--- a/src/components/listings/ListingCard.tsx
+++ b/src/components/listings/ListingCard.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import Link from "next/link";
+import type { ListingResponseDto } from "@/lib/types/listing";
+
+export default function ListingCard({ it }: { it: ListingResponseDto }) {
+    const img = it.images?.[0]?.url ?? "/listing-placeholder.jpg";
+    const isTrade = it.type === "TRADE";
+    const badge = isTrade ? "Takas" : (it.price ? `${formatMoney(it.price, it.currency)}` : "Satış");
+
+    return (
+        <Link href={`/listings/${it.id}`} className="group block overflow-hidden rounded-xl border border-white/10 bg-neutral-900 hover:border-white/20">
+            <div className="relative aspect-[4/3] w-full overflow-hidden">
+                {/* eslint-disable-next-line @next/next/no-img-element */}
+                <img src={img} alt={it.title} className="h-full w-full object-cover transition-transform duration-300 group-hover:scale-[1.03]" />
+                <div className="absolute left-2 top-2 rounded-md bg-black/60 px-2 py-0.5 text-xs font-semibold text-white shadow">
+                    {it.brandName ?? "—"}
+                </div>
+            </div>
+            <div className="space-y-1 p-3">
+                <div className="line-clamp-1 font-semibold">{it.title}</div>
+                <div className="text-xs text-neutral-400">
+                    {(it.modelName ?? it.seriesName ?? it.theme ?? "").toString()}
+                    {it.scale ? ` • ${it.scale}` : ""}
+                    {it.modelYear ? ` • ${it.modelYear}` : ""}
+                </div>
+                <div className="flex items-center justify-between pt-1">
+                    <span className={`rounded-md px-2 py-0.5 text-xs font-bold ${isTrade ? "bg-violet-500/15 text-violet-300" : "bg-emerald-500/15 text-emerald-300"}`}>
+                        {badge}
+                    </span>
+                    {it.location && <span className="text-xs text-neutral-400">{it.location}</span>}
+                </div>
+            </div>
+        </Link>
+    );
+}
+
+function formatMoney(v: number | string | null | undefined, cur?: string | null) {
+    const n = typeof v === "string" ? Number(v) : v ?? 0;
+    return new Intl.NumberFormat("tr-TR", { style: "currency", currency: cur ?? "TRY", maximumFractionDigits: 0 }).format(n);
+}

--- a/src/components/listings/ListingFilters.tsx
+++ b/src/components/listings/ListingFilters.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import type { ListingsSearchParams } from "@/lib/queries/listings";
+
+export type Filters = Pick<ListingsSearchParams, "type" | "priceMin" | "priceMax" | "sortBy" | "sortDir" | "size">;
+
+export default function ListingFilters({ value, onChange }: { value: Filters; onChange: (f: Filters) => void }) {
+    const [local, setLocal] = useState<Filters>(value);
+
+    useEffect(() => setLocal(value), [value]);
+
+    return (
+        <div className="grid gap-3 rounded-xl border border-white/10 bg-neutral-900 p-3 sm:grid-cols-3 lg:grid-cols-6">
+            <select
+                value={local.type ?? ""}
+                onChange={(e) => setLocal({ ...local, type: (e.target.value || undefined) as Filters["type"] })}
+                className="input"
+            >
+                <option value="">Tür: Hepsi</option>
+                <option value="SALE">Satış</option>
+                <option value="TRADE">Takas</option>
+            </select>
+
+            <input
+                type="number" min={0} placeholder="Fiyat min"
+                value={local.priceMin ?? ""} onChange={(e) => setLocal({ ...local, priceMin: e.target.value ? Number(e.target.value) : undefined })}
+                className="input"
+            />
+            <input
+                type="number" min={0} placeholder="Fiyat max"
+                value={local.priceMax ?? ""} onChange={(e) => setLocal({ ...local, priceMax: e.target.value ? Number(e.target.value) : undefined })}
+                className="input"
+            />
+
+            <select
+                value={local.sortBy ?? "createdAt"}
+                onChange={(e) => setLocal({ ...local, sortBy: e.target.value as Filters["sortBy"] })}
+                className="input"
+            >
+                <option value="createdAt">Sırala: Yeni</option>
+                <option value="price">Fiyat</option>
+                <option value="modelYear">Model Yılı</option>
+            </select>
+
+            <select
+                value={local.sortDir ?? "DESC"}
+                onChange={(e) => setLocal({ ...local, sortDir: e.target.value as Filters["sortDir"] })}
+                className="input"
+            >
+                <option value="DESC">Azalan</option>
+                <option value="ASC">Artan</option>
+            </select>
+
+            <select
+                value={local.size ?? 24}
+                onChange={(e) => setLocal({ ...local, size: Number(e.target.value) })}
+                className="input"
+            >
+                <option value="12">12 / sayfa</option>
+                <option value="24">24 / sayfa</option>
+                <option value="48">48 / sayfa</option>
+            </select>
+
+            <div className="sm:col-span-3 lg:col-span-6 flex gap-2">
+                <button
+                    onClick={() => onChange(local)}
+                    className="rounded-lg bg-gradient-to-r from-sky-400 to-blue-600 px-4 py-2 text-sm font-semibold text-white"
+                >
+                    Filtreleri Uygula
+                </button>
+                <button
+                    onClick={() => { const reset: Filters = { type: undefined, priceMin: undefined, priceMax: undefined, sortBy: "createdAt", sortDir: "DESC", size: 24 }; setLocal(reset); onChange(reset); }}
+                    className="rounded-lg border border-white/15 px-4 py-2 text-sm font-semibold"
+                >
+                    Sıfırla
+                </button>
+            </div>
+        </div>
+    );
+}

--- a/src/lib/queries/listings.ts
+++ b/src/lib/queries/listings.ts
@@ -1,0 +1,84 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { api } from "@/lib/api";
+import type { ListingResponseDto, Page } from "@/lib/types/listing";
+
+export const qkListings = {
+    search: (key: string) => ["listings","search",key] as const,
+    byId: (id: number) => ["listings","byId",id] as const,
+};
+
+export type ListingsSearchParams = {
+    q?: string;               // free text: backend’de yoksa şimdilik pas
+    brandIds?: number[];
+    seriesIds?: number[];
+    tagIds?: number[];
+    theme?: string;
+    scale?: string;
+    condition?: string;
+    limitedEdition?: boolean;
+    type?: "SALE" | "TRADE";
+    status?: "ACTIVE" | "SOLD" | "WITHDRAWN";
+    location?: string;
+    modelYearFrom?: number;
+    modelYearTo?: number;
+    priceMin?: number;
+    priceMax?: number;
+    page?: number;   // 0-based
+    size?: number;   // default 20
+    sortBy?: string; // createdAt | price | modelYear
+    sortDir?: "ASC" | "DESC";
+};
+
+const toQuery = (p: ListingsSearchParams = {}) => {
+    const u = new URLSearchParams();
+    const arr = (k: string, v?: number[]) => v?.forEach(x => u.append(k, String(x)));
+    const str = (k: string, v?: string | number | boolean) => (v !== undefined && v !== null && v !== "" ? u.set(k, String(v)) : null);
+
+    arr("brandIds", p.brandIds);
+    arr("seriesIds", p.seriesIds);
+    arr("tagIds", p.tagIds);
+
+    str("theme", p.theme);
+    str("scale", p.scale);
+    str("condition", p.condition);
+    str("limitedEdition", p.limitedEdition);
+    str("type", p.type);
+    str("status", p.status);
+    str("location", p.location);
+    str("modelYearFrom", p.modelYearFrom);
+    str("modelYearTo", p.modelYearTo);
+    str("priceMin", p.priceMin);
+    str("priceMax", p.priceMax);
+    str("page", p.page ?? 0);
+    str("size", p.size ?? 24);
+    str("sortBy", p.sortBy ?? "createdAt");
+    str("sortDir", p.sortDir ?? "DESC");
+
+    return u.toString();
+};
+
+export function useListingsSearch(p: ListingsSearchParams) {
+    const qs = toQuery(p);
+    return useQuery({
+        queryKey: qkListings.search(qs),
+        queryFn: async (): Promise<Page<ListingResponseDto>> => {
+            const res = await api.get(`/cars/listings?${qs}`);
+            return res.data;
+        },
+        staleTime: 30_000,
+    });
+}
+
+export function useListingById(id: number) {
+    return useQuery({
+        queryKey: qkListings.byId(id),
+        queryFn: async (): Promise<ListingResponseDto> => {
+            const res = await api.get(`/cars/listings/${id}`);
+            return res.data;
+        },
+        enabled: Number.isFinite(id),
+        staleTime: 30_000,
+    });
+}

--- a/src/lib/types/listing.ts
+++ b/src/lib/types/listing.ts
@@ -1,0 +1,61 @@
+export type TagDto = {
+    id: number;
+    name: string;
+    slug: string;
+};
+
+export type ListingImageDto = {
+    id: number;
+    url: string;
+    idx: number;
+};
+
+export type ListingSellerDto = {
+    userId: number;
+    username?: string | null;
+    displayName?: string | null;
+    avatarUrl?: string | null;
+    location?: string | null;
+};
+
+export type ListingResponseDto = {
+    id: number;
+    seller?: ListingSellerDto | null;
+
+    title: string;
+    description?: string | null;
+
+    brandId?: number | null;
+    seriesId?: number | null;
+    brandName?: string | null;
+    seriesName?: string | null;
+    modelName?: string | null;
+    scale?: string | null;
+    modelYear?: number | null;
+    condition?: string | null;
+    limitedEdition?: boolean | null;
+    theme?: string | null;
+    countryOfOrigin?: string | null;
+
+    type: "SALE" | "TRADE";
+    price?: string | number | null;
+    currency?: string | null;
+    location?: string | null;
+
+    status: "ACTIVE" | "SOLD" | "WITHDRAWN";
+    isActive?: boolean | null;
+
+    createdAt?: string | null;
+    updatedAt?: string | null;
+
+    images?: ListingImageDto[];
+    tags?: TagDto[];
+};
+
+export type Page<T> = {
+    content: T[];
+    totalElements: number;
+    totalPages: number;
+    size: number;
+    number: number; // current page (0-based)
+};

--- a/src/lib/types/profile.ts
+++ b/src/lib/types/profile.ts
@@ -103,8 +103,8 @@ export interface ProfileUpdateRequest {
     isPublic?: boolean | null;
 }
 
-export interface ProfilePrefsUpdateRequest extends ProfilePrefsDto {}
-export interface NotificationSettingsUpdateRequest extends NotificationSettingsDto {}
+export type ProfilePrefsUpdateRequest = ProfilePrefsDto;
+export type NotificationSettingsUpdateRequest = NotificationSettingsDto;
 
 export interface UsernameAvailabilityDto { available: boolean; }
 export interface UsernameSuggestionsDto { candidates: string[]; }


### PR DESCRIPTION
## Summary
- add type definitions and React Query hooks for car listings
- build listing card, filters, list and detail pages
- add global input style and allow remote image sources

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b45d3f0dfc832ebb6a084bf20fc89d