### PR TITLE
feat: add collections pages

### DIFF
--- a/src/app/collections/[slug]/page.tsx
+++ b/src/app/collections/[slug]/page.tsx
@@ -1,0 +1,226 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import Link from "next/link";
+
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE ?? "http://localhost:8080";
+
+type ListingImage = { url: string; idx?: number };
+type Listing = {
+  id: number;
+  title: string;
+  brandName?: string;
+  seriesName?: string;
+  modelName?: string;
+  price?: number;
+  currency?: string;
+  images?: ListingImage[];
+};
+
+type PageResponse = {
+  content: Listing[];
+  totalElements: number;
+  totalPages: number;
+  size: number;
+  number: number; // current page
+};
+
+const THEME_BY_SLUG: Record<string, string> = {
+  "fast-and-furious": "Fast & Furious",
+  jdm: "JDM",
+  "bond-007": "007",
+  "euro-legends": "Euro",
+  "usdm-muscle": "USDM",
+  rally: "Rally",
+  lemans: "Le Mans",
+  supercars: "Supercar",
+  "movie-cars": "Movie Car",
+  classic: "Classic",
+};
+
+// Basit fiyat yazımı
+const fmtPrice = (p?: number, c?: string) =>
+  typeof p === "number" ? `${p} ${c ?? ""}` : "";
+
+export default function CollectionDetailPage({
+  params,
+  searchParams,
+}: {
+  params: { slug: string };
+  searchParams: { page?: string };
+}) {
+  const slug = params.slug;
+  const pageIdx = Math.max(0, parseInt(searchParams.page ?? "0", 10) || 0);
+
+  const [data, setData] = useState<PageResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [err, setErr] = useState<string | null>(null);
+
+  const title = useMemo(() => {
+    // Başlık: map’te varsa onu kullan, yoksa slug’ı başlık formatla
+    return THEME_BY_SLUG[slug] ?? slug.replace(/-/g, " ").replace(/\b\w/g, (m) => m.toUpperCase());
+  }, [slug]);
+
+  useEffect(() => {
+    let canceled = false;
+
+    async function run() {
+      try {
+        setLoading(true);
+        setErr(null);
+
+        const theme = THEME_BY_SLUG[slug];
+
+        // 1) THEME ile ara (varsa)
+        if (theme) {
+          const url = new URL(`${API_BASE}/api/v1/cars/listings`);
+          url.searchParams.set("theme", theme);
+          url.searchParams.set("status", "ACTIVE");
+          url.searchParams.set("page", String(pageIdx));
+          url.searchParams.set("size", "24");
+          url.searchParams.set("sortBy", "createdAt");
+          url.searchParams.set("sortDir", "DESC");
+
+          const res = await fetch(url.toString(), { cache: "no-store" });
+          if (!res.ok) throw new Error(`HTTP ${res.status}`);
+          const json: PageResponse = await res.json();
+          if (!canceled) setData(json);
+          return;
+        }
+
+        // 2) Tag slug çöz (yoksa): /tags -> /listings?tagIds=...
+        const tagsRes = await fetch(`${API_BASE}/api/v1/cars/tags`, { cache: "no-store" });
+        if (!tagsRes.ok) throw new Error(`Tags HTTP ${tagsRes.status}`);
+        const tags: { id: number; name: string; slug: string }[] = await tagsRes.json();
+        const tag = tags.find((t) => t.slug.toLowerCase() === slug.toLowerCase());
+
+        const url = new URL(`${API_BASE}/api/v1/cars/listings`);
+        if (tag) url.searchParams.set("tagIds", String(tag.id));
+        else url.searchParams.set("theme", title); // son çare: slug->başlık theme olarak dene
+        url.searchParams.set("status", "ACTIVE");
+        url.searchParams.set("page", String(pageIdx));
+        url.searchParams.set("size", "24");
+        url.searchParams.set("sortBy", "createdAt");
+        url.searchParams.set("sortDir", "DESC");
+
+        const res2 = await fetch(url.toString(), { cache: "no-store" });
+        if (!res2.ok) throw new Error(`HTTP ${res2.status}`);
+        const json2: PageResponse = await res2.json();
+        if (!canceled) setData(json2);
+      } catch (e: unknown) {
+        if (!canceled) {
+          const message = e instanceof Error ? e.message : "Beklenmeyen hata";
+          setErr(message);
+        }
+      } finally {
+        if (!canceled) setLoading(false);
+      }
+    }
+
+    run();
+    return () => {
+      canceled = true;
+    };
+  }, [slug, pageIdx, title]);
+
+  return (
+    <div className="min-h-screen bg-neutral-50 text-neutral-900 dark:bg-neutral-950 dark:text-neutral-100">
+      {/* HERO mini */}
+      <section className="border-b border-neutral-200 dark:border-white/10">
+        <div className="mx-auto max-w-6xl px-4 py-8">
+          <nav className="text-sm">
+            <Link href="/" className="text-sky-400 hover:underline">
+              Anasayfa
+            </Link>
+            <span className="mx-2 text-neutral-500">/</span>
+            <Link href="/collections" className="text-sky-400 hover:underline">
+              Koleksiyonlar
+            </Link>
+            <span className="mx-2 text-neutral-500">/</span>
+            <span className="text-neutral-300">{title}</span>
+          </nav>
+          <h1 className="mt-2 text-3xl font-extrabold">{title}</h1>
+          <p className="mt-1 text-neutral-600 dark:text-neutral-400">
+            Bu temaya ait aktif ilanlar.
+          </p>
+        </div>
+      </section>
+
+      {/* STATE’ler */}
+      <section className="mx-auto max-w-6xl px-4 py-8">
+        {loading && <div className="text-sm text-neutral-400">Yükleniyor…</div>}
+        {err && (
+          <div className="text-sm text-red-400">
+            Hata: {err} — Daha sonra tekrar deneyin.
+          </div>
+        )}
+        {!loading && !err && data && data.content.length === 0 && (
+          <div className="text-sm text-neutral-400">
+            Bu koleksiyon için aktif ilan bulunamadı.
+          </div>
+        )}
+
+        {/* GRID */}
+        {data && data.content.length > 0 && (
+          <>
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+              {data.content.map((t) => (
+                <article
+                  key={t.id}
+                  className="group overflow-hidden rounded-2xl border border-neutral-200 dark:border-white/10 bg-white dark:bg-neutral-900 shadow-sm hover:shadow-md transition-shadow"
+                >
+                  <div className="relative">
+                    <img
+                      src={
+                        t.images?.[0]?.url ??
+                        "https://picsum.photos/seed/fallback/800/600"
+                      }
+                      alt={t.title}
+                      className="h-44 w-full object-cover transition-transform duration-300 group-hover:scale-[1.03]"
+                    />
+                    {(t.brandName || t.seriesName) && (
+                      <span className="absolute top-2 left-2 rounded-md bg-gradient-to-r from-sky-400 to-blue-600 text-white text-xs font-bold px-2 py-1 shadow-sm ring-1 ring-white/30">
+                        {t.brandName ?? t.seriesName}
+                      </span>
+                    )}
+                  </div>
+                  <div className="p-4">
+                    <h3 className="font-bold line-clamp-1">{t.title}</h3>
+                    <p className="text-xs text-neutral-500 dark:text-neutral-400 line-clamp-1">
+                      {t.modelName ?? t.seriesName ?? ""}
+                    </p>
+                    <p className="mt-1 text-sm">
+                      {fmtPrice(t.price, t.currency)}
+                    </p>
+                  </div>
+                </article>
+              ))}
+            </div>
+
+            {/* Basit sayfalama (ileri/geri) */}
+            <div className="mt-6 flex items-center justify-center gap-3">
+              {pageIdx > 0 && (
+                <Link
+                  href={`/collections/${slug}?page=${pageIdx - 1}`}
+                  className="rounded-lg border border-neutral-300 dark:border-white/20 px-3 py-1.5 text-sm hover:bg-white/10"
+                >
+                  ← Önceki
+                </Link>
+              )}
+              {data.number + 1} / {data.totalPages || 1}
+              {data.number + 1 < data.totalPages && (
+                <Link
+                  href={`/collections/${slug}?page=${pageIdx + 1}`}
+                  className="rounded-lg border border-neutral-300 dark:border-white/20 px-3 py-1.5 text-sm hover:bg-white/10"
+                >
+                  Sonraki →
+                </Link>
+              )}
+            </div>
+          </>
+        )}
+      </section>
+    </div>
+  );
+}
+

--- a/src/app/collections/page.tsx
+++ b/src/app/collections/page.tsx
@@ -1,0 +1,141 @@
+"use client";
+
+import Link from "next/link";
+
+type Collection = {
+  slug: string;
+  title: string;
+  subtitle: string;
+  image: string;
+};
+
+const collections: Collection[] = [
+  {
+    slug: "fast-and-furious",
+    title: "Fast & Furious",
+    subtitle: "Film serisinin efsane cast’ı",
+    image:
+      "https://images.unsplash.com/photo-1511919884226-fd3cad34687c?q=80&w=1600&auto=format&fit=crop",
+  },
+  {
+    slug: "jdm",
+    title: "JDM",
+    subtitle: "Japon efsaneleri: Skyline, Supra, RX-7…",
+    image:
+      "https://images.unsplash.com/photo-1503376780353-7e6692767b70?q=80&w=1600&auto=format&fit=crop",
+  },
+  {
+    slug: "bond-007",
+    title: "James Bond 007",
+    subtitle: "Aston Martin ve ajan ruhu",
+    image:
+      "https://images.unsplash.com/photo-1525609004556-c46c7d6cf023?q=80&w=1600&auto=format&fit=crop",
+  },
+  {
+    slug: "euro-legends",
+    title: "Euro Legends",
+    subtitle: "Porsche, Ferrari, Lambo, AMG",
+    image:
+      "https://images.unsplash.com/photo-1503376780353-7e6692767b70?q=80&w=1600&auto=format&fit=crop",
+  },
+  {
+    slug: "usdm-muscle",
+    title: "USDM Muscle",
+    subtitle: "V8 gürültüsü, saf güç",
+    image:
+      "https://images.unsplash.com/photo-1511300636408-a63a89df3482?q=80&w=1600&auto=format&fit=crop",
+  },
+  {
+    slug: "rally",
+    title: "Ralli Efsaneleri",
+    subtitle: "Grup B nostaljisi",
+    image:
+      "https://images.unsplash.com/photo-1511397461313-52114189c134?q=80&w=1600&auto=format&fit=crop",
+  },
+  {
+    slug: "lemans",
+    title: "Le Mans",
+    subtitle: "Dayanıklılığın zirvesi",
+    image:
+      "https://images.unsplash.com/photo-1518081461904-9ac6f7fc2549?q=80&w=1600&auto=format&fit=crop",
+  },
+  {
+    slug: "supercars",
+    title: "Supercars",
+    subtitle: "Hiper performans, hiper tasarım",
+    image:
+      "https://images.unsplash.com/photo-1511919884226-fd3cad34687c?q=80&w=1600&auto=format&fit=crop",
+  },
+  {
+    slug: "movie-cars",
+    title: "Movie Cars",
+    subtitle: "Sinemanın unutulmazları",
+    image:
+      "https://images.unsplash.com/photo-1525609004556-c46c7d6cf023?q=80&w=1600&auto=format&fit=crop",
+  },
+  {
+    slug: "classic",
+    title: "Klasikler",
+    subtitle: "Zamana meydan okuyanlar",
+    image:
+      "https://images.unsplash.com/photo-1483721310020-03333e577078?q=80&w=1600&auto=format&fit=crop",
+  },
+];
+
+export default function CollectionsPage() {
+  return (
+    <div className="min-h-screen bg-neutral-50 text-neutral-900 dark:bg-neutral-950 dark:text-neutral-100">
+      {/* HERO */}
+      <section className="relative border-b border-neutral-200 dark:border-white/10">
+        <div
+          className="h-[340px] bg-cover bg-center"
+          style={{
+            backgroundImage:
+              "linear-gradient(rgba(2,132,199,.25), rgba(2,132,199,.45)), url('https://images.unsplash.com/photo-1520975922284-5f7f83a43dfd?q=80&w=1800&auto=format&fit=crop')",
+          }}
+          aria-hidden
+        />
+        <div className="pointer-events-none absolute inset-0">
+          <div className="absolute -top-20 -left-24 w-[60%] h-52 rotate-[10deg] bg-gradient-to-r from-white/25 to-transparent blur-2xl" />
+          <div className="absolute bottom-[-60px] right-[-60px] w-72 h-72 bg-sky-500/20 blur-3xl rounded-full" />
+        </div>
+        <div className="absolute inset-0 grid place-items-center">
+          <div className="mx-auto max-w-6xl px-4 text-white">
+            <h1 className="mt-2 text-3xl sm:text-5xl font-extrabold leading-tight tracking-tight">
+              Koleksiyonlar
+            </h1>
+            <p className="mt-2 max-w-2xl text-white/90">
+              Temaya göre kürasyon: film efsaneleri, JDM, klasikler, ralli ve daha fazlası.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      {/* GRID */}
+      <section className="mx-auto max-w-6xl px-4 py-10">
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-5">
+          {collections.map((c) => (
+            <Link
+              key={c.slug}
+              href={`/collections/${c.slug}`}
+              className="group relative overflow-hidden rounded-2xl border border-neutral-200 dark:border-white/10 bg-white dark:bg-neutral-900 shadow-sm hover:shadow-md transition-shadow"
+            >
+              <img
+                src={c.image}
+                alt={c.title}
+                className="h-48 w-full object-cover transition-transform duration-300 group-hover:scale-[1.03]"
+              />
+              <div className="p-4">
+                <h3 className="font-bold text-lg">{c.title}</h3>
+                <p className="text-sm text-neutral-600 dark:text-neutral-400">
+                  {c.subtitle}
+                </p>
+              </div>
+            </Link>
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add curated collections grid and detail pages
- support theme or tag-based listing search

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx eslint src/app/collections/page.tsx src/app/collections/[slug]/page.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b4c34d2258832e989ed380ec125534