### PR TITLE
feat: add auction UI

### DIFF
--- a/src/app/auctions/[id]/page.tsx
+++ b/src/app/auctions/[id]/page.tsx
@@ -1,0 +1,79 @@
+"use client";
+import Link from "next/link";
+import { useParams } from "next/navigation";
+import { useAuction, useAuctionBids } from "@/lib/queries/auction";
+import { formatTRY } from "@/lib/format";
+import AuctionTimer from "@/components/auction/AuctionTimer";
+import BidForm from "@/components/auction/BidForm";
+import BidList from "@/components/auction/BidList";
+
+export default function AuctionDetailPage() {
+  const params = useParams<{ id: string }>();
+  const id = Number(params.id);
+  const { data: auction, isLoading, isError } = useAuction(id, 5_000);      // 5sn polling
+  const { data: bids } = useAuctionBids(id, auction?.status === "ACTIVE" ? 5_000 : undefined);
+
+  if (isLoading) {
+    return <div className="mx-auto max-w-6xl px-4 py-6 text-sm text-neutral-400">Yükleniyor…</div>;
+  }
+  if (isError || !auction) {
+    return <div className="mx-auto max-w-6xl px-4 py-6 text-sm text-red-400">Mezat bulunamadı.</div>;
+  }
+
+  const highest = auction.highestBidAmount ? Number(auction.highestBidAmount) : null;
+
+  return (
+    <div className="mx-auto max-w-6xl px-4 py-6 grid gap-6">
+      {/* Breadcrumb */}
+      <nav className="text-sm">
+        <Link href="/" className="text-sky-400 hover:underline">Anasayfa</Link>
+        <span className="mx-2 text-neutral-500">/</span>
+        <Link href="/auctions" className="text-sky-400 hover:underline">Mezat</Link>
+        <span className="mx-2 text-neutral-500">/</span>
+        <span className="text-neutral-300">#{auction.id}</span>
+      </nav>
+
+      {/* Üst bilgi */}
+      <section className="rounded-2xl border border-neutral-200 dark:border-white/10 p-5 bg-white dark:bg-neutral-900 shadow-sm grid gap-4">
+        <div className="flex items-center justify-between">
+          <h1 className="text-xl font-extrabold">Mezat #{auction.id}</h1>
+          <AuctionTimer endsAt={auction.endsAt} />
+        </div>
+
+        <div className="grid sm:grid-cols-3 gap-3">
+          <Stat label="Durum" value={auction.status} />
+          <Stat label="Başlangıç" value={formatTRY(auction.startPrice)} />
+          <Stat label="En yüksek teklif" value={highest ? formatTRY(highest) : "-"} />
+        </div>
+
+        <img
+          src={`https://picsum.photos/seed/auction-${auction.id}/1200/600`}
+          alt="auction"
+          className="rounded-xl border border-neutral-200 dark:border-white/10 h-56 w-full object-cover"
+        />
+      </section>
+
+      {/* 2 kolon: Bid form + Bid list */}
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+        <section className="lg:col-span-2 rounded-2xl border border-neutral-200 dark:border-white/10 p-5 bg-white dark:bg-neutral-900 shadow-sm">
+          <h2 className="text-lg font-bold mb-3">Teklifler</h2>
+          <BidList bids={bids ?? []} />
+        </section>
+
+        <section className="rounded-2xl border border-neutral-200 dark:border-white/10 p-5 bg-white dark:bg-neutral-900 shadow-sm">
+          <h2 className="text-lg font-bold mb-3">Teklif Ver</h2>
+          <BidForm auction={auction} />
+        </section>
+      </div>
+    </div>
+  );
+}
+
+function Stat({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-xl border border-neutral-200 dark:border-white/10 p-4">
+      <div className="text-xs text-neutral-500">{label}</div>
+      <div className="text-lg font-semibold">{value}</div>
+    </div>
+  );
+}

--- a/src/app/auctions/page.tsx
+++ b/src/app/auctions/page.tsx
@@ -1,0 +1,38 @@
+"use client";
+import Link from "next/link";
+import { useAuctions } from "@/lib/queries/auction";
+import AuctionCard from "@/components/auction/AuctionCard";
+
+export default function AuctionsPage() {
+  const { data, isLoading, isError } = useAuctions();
+
+  return (
+    <div className="mx-auto max-w-6xl px-4 py-6 grid gap-6">
+      {/* Breadcrumb */}
+      <nav className="text-sm">
+        <Link href="/" className="text-sky-400 hover:underline">Anasayfa</Link>
+        <span className="mx-2 text-neutral-500">/</span>
+        <span className="text-neutral-300">Mezat</span>
+      </nav>
+
+      <header className="flex items-end justify-between gap-3">
+        <div>
+          <h1 className="text-2xl font-extrabold">Mezatlar</h1>
+          <p className="text-sm text-neutral-500">Devam eden açık artırmalar</p>
+        </div>
+        {/* İleri: /auctions/new eklenirse burada CTA olur */}
+      </header>
+
+      {isLoading && <p className="text-sm text-neutral-400">Yükleniyor…</p>}
+      {isError && <p className="text-sm text-red-400">Mezatlar alınamadı.</p>}
+
+      {data?.length ? (
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+          {data.map((a) => <AuctionCard key={a.id} a={a} />)}
+        </div>
+      ) : (
+        !isLoading && <p className="text-sm text-neutral-400">Şu an aktif mezat yok.</p>
+      )}
+    </div>
+  );
+}

--- a/src/components/auction/AuctionCard.tsx
+++ b/src/components/auction/AuctionCard.tsx
@@ -1,0 +1,39 @@
+import Link from "next/link";
+import AuctionTimer from "./AuctionTimer";
+import { formatTRY } from "@/lib/format";
+import type { AuctionListItemDto } from "@/lib/types/auction";
+
+export default function AuctionCard({ a }: { a: AuctionListItemDto }) {
+  return (
+    <Link
+      href={`/auctions/${a.id}`}
+      className="group block overflow-hidden rounded-2xl border border-neutral-200 dark:border-white/10 bg-white dark:bg-neutral-900 shadow-sm hover:shadow-md transition-shadow"
+    >
+      {/* Görsel - şimdilik placeholder */}
+      <div className="relative">
+        <img
+          src={`https://picsum.photos/seed/auction-${a.id}/800/480`}
+          alt="Auction"
+          className="h-40 w-full object-cover transition-transform duration-300 group-hover:scale-[1.03]"
+        />
+        <span className="absolute top-2 left-2 rounded-md bg-neutral-900/80 text-white text-xs font-bold px-2 py-1">
+          #{a.id}
+        </span>
+      </div>
+
+      <div className="p-4 grid gap-1">
+        <div className="flex items-center justify-between text-sm">
+          <span className="text-neutral-500 dark:text-neutral-400">Başlangıç</span>
+          <span className="font-semibold">{formatTRY(a.startPrice)}</span>
+        </div>
+        <div className="flex items-center justify-between text-sm">
+          <span className="text-neutral-500 dark:text-neutral-400">En yüksek</span>
+          <span className="font-semibold">{a.highestBidAmount ? formatTRY(a.highestBidAmount) : "-"}</span>
+        </div>
+        <div className="pt-2">
+          <AuctionTimer endsAt={a.endsAt} />
+        </div>
+      </div>
+    </Link>
+  );
+}

--- a/src/components/auction/AuctionTimer.tsx
+++ b/src/components/auction/AuctionTimer.tsx
@@ -1,0 +1,18 @@
+"use client";
+import { useCountdown } from "@/hooks/useCountdown";
+
+export default function AuctionTimer({ endsAt }: { endsAt: string }) {
+  const { d, h, m, s, finished } = useCountdown(endsAt);
+  if (finished) {
+    return <span className="inline-flex items-center rounded px-2 py-0.5 text-xs bg-red-600/20 text-red-300">Sona erdi</span>;
+  }
+  return (
+    <span className="inline-flex items-center rounded px-2 py-0.5 text-xs bg-emerald-600/15 text-emerald-300">
+      {d ? `${d}g ` : ""}
+      {h.toString().padStart(2,"0")}:
+      {m.toString().padStart(2,"0")}:
+      {s.toString().padStart(2,"0")}
+      {" "}kaldı
+    </span>
+  );
+}

--- a/src/components/auction/BidForm.tsx
+++ b/src/components/auction/BidForm.tsx
@@ -1,0 +1,63 @@
+"use client";
+import { useEffect, useState } from "react";
+import { formatTRY, toMinBid } from "@/lib/format";
+import { usePlaceBid } from "@/lib/queries/auction";
+import type { AuctionResponseDto } from "@/lib/types/auction";
+import { useToast } from "@/components/ui/toast";
+
+export default function BidForm({ auction }: { auction: AuctionResponseDto }) {
+  const highest = auction.highestBidAmount ? Number(auction.highestBidAmount) : null;
+  const start = Number(auction.startPrice);
+  const min = toMinBid(start, highest);
+  const [amount, setAmount] = useState<number>(min);
+  const m = usePlaceBid(auction.id);
+  const { push } = useToast();
+
+  useEffect(() => {
+    // auction güncellendiğinde min değişebilir
+    const newMin = toMinBid(Number(auction.startPrice), auction.highestBidAmount ? Number(auction.highestBidAmount) : null);
+    setAmount((prev) => (prev < newMin ? newMin : prev));
+  }, [auction.startPrice, auction.highestBidAmount]);
+
+  const disabled = auction.status !== "ACTIVE";
+
+  const submit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (amount < min) return;
+    m.mutate(
+      { amount },
+      {
+        onSuccess: () => {
+          push({ type: "success", title: "Teklif verildi", description: `${formatTRY(amount)} ile teklifiniz alındı.` });
+        },
+        onError: (err) => {
+          push({ type: "error", title: "Teklif başarısız", description: err instanceof Error ? err.message : "Hata oluştu" });
+        },
+      }
+    );
+  };
+
+  return (
+    <form onSubmit={submit} className="grid sm:grid-cols-[1fr_auto] gap-3">
+      <div>
+        <label className="text-xs text-neutral-400">Minimum tutar</label>
+        <input
+          type="number"
+          min={min}
+          step={1}
+          value={amount}
+          onChange={(e) => setAmount(Number(e.target.value))}
+          className="mt-1 w-full rounded-lg border border-neutral-300 dark:border-neutral-700 bg-white/90 dark:bg-neutral-900 px-3 py-2 outline-none"
+        />
+        <p className="mt-1 text-xs text-neutral-500">En az {formatTRY(min)} teklif verebilirsiniz.</p>
+      </div>
+      <button
+        type="submit"
+        disabled={disabled || m.isPending}
+        className="h-10 self-end rounded-lg bg-gradient-to-r from-sky-400 to-blue-600 px-4 text-white font-semibold disabled:opacity-60"
+      >
+        {disabled ? "Aktif Değil" : m.isPending ? "Gönderiliyor…" : "Teklif Ver"}
+      </button>
+    </form>
+  );
+}

--- a/src/components/auction/BidList.tsx
+++ b/src/components/auction/BidList.tsx
@@ -1,0 +1,19 @@
+"use client";
+import type { BidResponseDto } from "@/lib/types/auction";
+import { formatTRY } from "@/lib/format";
+
+export default function BidList({ bids }: { bids: BidResponseDto[] }) {
+  if (!bids.length) {
+    return <p className="text-sm text-neutral-500">Henüz teklif yok.</p>;
+  }
+  return (
+    <ul className="grid gap-2">
+      {bids.map((b) => (
+        <li key={b.id} className="flex items-center justify-between rounded-lg border border-neutral-200 dark:border-white/10 px-3 py-2">
+          <span className="text-sm text-neutral-400">kullanıcı #{b.bidderUserId}</span>
+          <span className="font-semibold">{formatTRY(b.amount)}</span>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/components/layout/SiteHeader.tsx
+++ b/src/components/layout/SiteHeader.tsx
@@ -19,6 +19,7 @@ export default function SiteHeader() {
                     <Link className="hover:text-neutral-900 dark:hover:text-white" href="/listings">Keşfet</Link>
                     <Link className="hover:text-neutral-900 dark:hover:text-white" href="/collections">Koleksiyonlar</Link>
                     <Link className="hover:text-neutral-900 dark:hover:text-white" href="/sell">Satış</Link>
+                    <Link className="hover:text-neutral-900 dark:hover:text-white" href="/auctions">Mezat</Link>
                     <Link className="hover:text-neutral-900 dark:hover:text-white" href="/about">Hakkımızda</Link>
                 </nav>
 

--- a/src/hooks/useCountdown.ts
+++ b/src/hooks/useCountdown.ts
@@ -1,0 +1,18 @@
+"use client";
+import { useEffect, useState } from "react";
+
+export function useCountdown(endsAtISO: string) {
+  const [now, setNow] = useState<Date>(() => new Date());
+  useEffect(() => {
+    const t = setInterval(() => setNow(new Date()), 1000);
+    return () => clearInterval(t);
+  }, []);
+  const end = new Date(endsAtISO);
+  const diff = Math.max(0, end.getTime() - now.getTime());
+  const s = Math.floor(diff / 1000);
+  const d = Math.floor(s / 86400);
+  const h = Math.floor((s % 86400) / 3600);
+  const m = Math.floor((s % 3600) / 60);
+  const sec = s % 60;
+  return { d, h, m, s: sec, finished: diff <= 0 };
+}

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -1,0 +1,11 @@
+export const formatTRY = (n?: string | number | null) => {
+  if (n === undefined || n === null) return "-";
+  const val = typeof n === "string" ? Number(n) : n;
+  if (Number.isNaN(val)) return "-";
+  return new Intl.NumberFormat("tr-TR", { style: "currency", currency: "TRY" }).format(val);
+};
+
+export const toMinBid = (startPrice: number, highest?: number | null) => {
+  const base = highest ?? startPrice;
+  return Math.round((base + 10) * 100) / 100; // +10 TL kuralı
+};

--- a/src/lib/queries/auction.ts
+++ b/src/lib/queries/auction.ts
@@ -1,0 +1,73 @@
+"use client";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { api } from "@/lib/api";
+import type {
+  AuctionListItemDto,
+  AuctionResponseDto,
+  BidResponseDto,
+  BidCreateRequest,
+  AuctionCreateRequest,
+} from "@/lib/types/auction";
+
+const AUCTIONS = "auctions";
+
+export function useAuctions() {
+  return useQuery({
+    queryKey: [AUCTIONS, "list"],
+    queryFn: async () => {
+      const { data } = await api.get<AuctionListItemDto[]>("/auctions");
+      return data;
+    },
+    staleTime: 10_000,
+  });
+}
+
+export function useAuction(id: number, refetchMs?: number) {
+  return useQuery({
+    queryKey: [AUCTIONS, "detail", id],
+    queryFn: async () => {
+      const { data } = await api.get<AuctionResponseDto>(`/auctions/${id}`);
+      return data;
+    },
+    refetchInterval: refetchMs,
+  });
+}
+
+export function useAuctionBids(id: number, refetchMs?: number) {
+  return useQuery({
+    queryKey: [AUCTIONS, "bids", id],
+    queryFn: async () => {
+      const { data } = await api.get<BidResponseDto[]>(`/auctions/${id}/bids`);
+      return data;
+    },
+    refetchInterval: refetchMs,
+  });
+}
+
+export function usePlaceBid(id: number) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async (payload: BidCreateRequest) => {
+      const { data } = await api.post<BidResponseDto>(`/auctions/${id}/bids`, payload);
+      return data;
+    },
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: [AUCTIONS, "detail", id] });
+      qc.invalidateQueries({ queryKey: [AUCTIONS, "bids", id] });
+      qc.invalidateQueries({ queryKey: [AUCTIONS, "list"] });
+    },
+  });
+}
+
+export function useCreateAuction() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async (payload: AuctionCreateRequest) => {
+      const { data } = await api.post<AuctionResponseDto>("/auctions", payload);
+      return data;
+    },
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: [AUCTIONS, "list"] });
+    },
+  });
+}

--- a/src/lib/types/auction.ts
+++ b/src/lib/types/auction.ts
@@ -1,0 +1,45 @@
+export type AuctionStatus = "SCHEDULED" | "ACTIVE" | "ENDED" | "CANCELLED";
+
+export interface AuctionListItemDto {
+  id: number;
+  listingId?: number | null;
+  startPrice: string | number;        // API BigDecimal string gelebilir
+  highestBidAmount?: string | number | null;
+  currency: string;                   // "TRY"
+  status: AuctionStatus;
+  endsAt: string;                     // ISO-8601
+}
+
+export interface AuctionResponseDto {
+  id: number;
+  sellerUserId: number;
+  listingId?: number | null;
+  startPrice: string | number;
+  currency: string;
+  startsAt: string;
+  endsAt: string;
+  status: AuctionStatus;
+  highestBidAmount?: string | number | null;
+  highestBidUserId?: number | null;
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+export interface BidResponseDto {
+  id: number;
+  auctionId: number;
+  bidderUserId: number;
+  amount: string | number;
+  createdAt: string;
+}
+
+export interface AuctionCreateRequest {
+  listingId?: number | null;
+  startPrice: string | number;
+  startsAt?: string | null;
+  endsAt: string; // ISO
+}
+
+export interface BidCreateRequest {
+  amount: string | number;
+}


### PR DESCRIPTION
## Summary
- implement auction types and react-query hooks
- add helpers and components for auctions
- create auction listing and detail pages with bidding support
- expose Mezat link in site header

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Unexpected any @typescript-eslint/no-explicit-any)


------
https://chatgpt.com/codex/tasks/task_e_68b72740bca8832ea7eea2103d30048a