### PR TITLE
Fix auction image upload hook usage

### DIFF
--- a/src/app/auctions/new/page.tsx
+++ b/src/app/auctions/new/page.tsx
@@ -9,6 +9,7 @@ const MAX_SIZE = 8 * 1024 * 1024;
 export default function AuctionNewPage() {
   const r = useRouter();
   const mCreate = useCreateAuction();
+  const mUpload = useUploadAuctionImages();
   const [files, setFiles] = useState<File[]>([]);
   const uploaderRef = useRef<HTMLInputElement|null>(null);
 
@@ -51,12 +52,9 @@ export default function AuctionNewPage() {
       location: form.location || undefined,
     });
 
-    /* eslint-disable react-hooks/rules-of-hooks */
     if (created?.id && files.length) {
-      const mUpload = useUploadAuctionImages(created.id);
-      await mUpload.mutateAsync(files);
+      await mUpload.mutateAsync({ id: created.id, files });
     }
-    /* eslint-enable react-hooks/rules-of-hooks */
     r.push(`/auctions/${created.id}`);
   };
 

--- a/src/lib/queries/auction.ts
+++ b/src/lib/queries/auction.ts
@@ -35,9 +35,9 @@ export const useCreateAuction = () => {
   });
 };
 
-export const useUploadAuctionImages = (id: number) =>
+export const useUploadAuctionImages = () =>
   useMutation({
-    mutationFn: async (files: File[]) => {
+    mutationFn: async ({ id, files }: { id: number; files: File[] }) => {
       const fd = new FormData();
       files.forEach((f) => fd.append("files", f));
       return (await api.post(`/auctions/${id}/images`, fd, {


### PR DESCRIPTION
## Summary
- Move auction image upload hook to component scope and pass auction id to mutation
- Use new hook structure in auction creation form to upload images after creating auction

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Unexpected any in unrelated files)*
- `npx eslint src/lib/queries/auction.ts src/app/auctions/new/page.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b75c48b010832e93113646786f4460