### PR TITLE
feat: add follow ui

### DIFF
--- a/src/components/me/MyStats.tsx
+++ b/src/components/me/MyStats.tsx
@@ -1,23 +1,43 @@
+"use client";
+import { useState } from "react";
 import type { ProfileOwnerDto } from "@/lib/types/profile";
+import Modal from "@/components/ui/Modal";
+import { FollowersList, FollowingList } from "@/components/profile/FollowList";
 
 export default function MyStats({ me }: { me: ProfileOwnerDto }) {
-    const s = me.stats ?? {};
-    const cards = [
-        { label: "Aktif İlan", value: s.listingsActiveCount ?? 0 },
-        { label: "Toplam İlan", value: s.listingsTotalCount ?? 0 },
-        { label: "Takipçi", value: s.followersCount ?? 0 },
-        { label: "Takip", value: s.followingCount ?? 0 },
-        { label: "Cevap Oranı", value: `${s.responseRate ?? 0}%` },
-    ];
+  const s = me.stats ?? {};
+  const cards = [
+    { key: "listingsActive", label: "Aktif İlan", value: s.listingsActiveCount ?? 0 },
+    { key: "listingsTotal",  label: "Toplam İlan", value: s.listingsTotalCount ?? 0 },
+    { key: "followers",      label: "Takipçi", value: s.followersCount ?? me.followersCount ?? 0, clickable: true },
+    { key: "following",      label: "Takip",   value: s.followingCount ?? me.followingCount ?? 0, clickable: true },
+    { key: "responseRate",   label: "Cevap Oranı", value: `${s.responseRate ?? 0}%` },
+  ];
 
-    return (
-        <section className="grid grid-cols-2 md:grid-cols-5 gap-3">
-            {cards.map((c) => (
-                <div key={c.label} className="rounded-xl border border-neutral-200 dark:border-white/10 p-4 bg-white dark:bg-neutral-900 text-center shadow-sm">
-                    <div className="text-2xl font-extrabold">{c.value}</div>
-                    <div className="text-xs text-neutral-500 dark:text-neutral-400">{c.label}</div>
-                </div>
-            ))}
-        </section>
-    );
+  const [open, setOpen] = useState<null | "followers" | "following">(null);
+
+  return (
+    <>
+      <section className="grid grid-cols-2 md:grid-cols-5 gap-3">
+        {cards.map((c) => (
+          <button
+            key={c.label}
+            className="rounded-xl border border-neutral-200 dark:border-white/10 p-4 bg-white dark:bg-neutral-900 text-center shadow-sm hover:shadow-md transition-shadow disabled:cursor-default"
+            onClick={() => c.clickable && setOpen(c.key === "followers" ? "followers" : "following")}
+            disabled={!c.clickable}
+          >
+            <div className="text-2xl font-extrabold">{c.value}</div>
+            <div className="text-xs text-neutral-500 dark:text-neutral-400">{c.label}</div>
+          </button>
+        ))}
+      </section>
+
+      <Modal open={open === "followers"} onClose={() => setOpen(null)} title="Takipçiler">
+        <FollowersList username={me.username} />
+      </Modal>
+      <Modal open={open === "following"} onClose={() => setOpen(null)} title="Takip Edilenler">
+        <FollowingList username={me.username} />
+      </Modal>
+    </>
+  );
 }

--- a/src/components/profile/FollowButton.tsx
+++ b/src/components/profile/FollowButton.tsx
@@ -1,0 +1,48 @@
+"use client";
+import { useState } from "react";
+import { useFollow, useUnfollow } from "@/lib/queries/profile";
+import { useToast } from "@/components/ui/toast";
+
+type Props = {
+  username: string;
+  initiallyFollowing?: boolean | null;
+  compact?: boolean; // küçük badge tarzı
+};
+
+export default function FollowButton({ username, initiallyFollowing, compact }: Props) {
+  const [isFollowing, setIsFollowing] = useState(!!initiallyFollowing);
+  const follow = useFollow(username);
+  const unfollow = useUnfollow(username);
+  const { push } = useToast();
+
+  const toggle = () => {
+    if (isFollowing) {
+      unfollow.mutate(undefined, {
+        onSuccess: () => { setIsFollowing(false); push({ type:"success", title:"Takipten çıkıldı" }); },
+        onError: (e) => push({ type:"error", title:"İşlem başarısız", description:String(e) }),
+      });
+    } else {
+      follow.mutate(undefined, {
+        onSuccess: () => { setIsFollowing(true); push({ type:"success", title:"Takip edildi" }); },
+        onError: (e) => push({ type:"error", title:"İşlem başarısız", description:String(e) }),
+      });
+    }
+  };
+
+  const loading = follow.isPending || unfollow.isPending;
+
+  return (
+    <button
+      onClick={toggle}
+      disabled={loading}
+      className={
+        isFollowing
+          ? "rounded-lg px-3 py-1.5 text-sm font-semibold bg-neutral-800 text-white hover:bg-neutral-700 disabled:opacity-60"
+          : "rounded-lg px-3 py-1.5 text-sm font-semibold text-white bg-gradient-to-r from-sky-400 to-blue-600 hover:opacity-95 disabled:opacity-60"
+      }
+      aria-pressed={isFollowing}
+    >
+      {loading ? "…" : isFollowing ? (compact ? "Takip" : "Takiptesin") : (compact ? "Takip Et" : "Takip Et")}
+    </button>
+  );
+}

--- a/src/components/profile/FollowList.tsx
+++ b/src/components/profile/FollowList.tsx
@@ -1,0 +1,37 @@
+"use client";
+import Link from "next/link";
+import { useFollowers, useFollowing } from "@/lib/queries/profile";
+
+export function FollowersList({ username }: { username: string }) {
+  const { data } = useFollowers(username, 0, 50);
+  if (!data) return null;
+  return <List items={data.items} empty="Henüz takipçi yok." />;
+}
+
+export function FollowingList({ username }: { username: string }) {
+  const { data } = useFollowing(username, 0, 50);
+  if (!data) return null;
+  return <List items={data.items} empty="Henüz kimseyi takip etmiyor." />;
+}
+
+function List({ items, empty }: { items: { username: string; displayName?: string; avatarUrl?: string; isVerified?: boolean | null }[]; empty: string }) {
+  if (!items.length) return <p className="text-sm text-neutral-400">{empty}</p>;
+  return (
+    <ul className="grid gap-3">
+      {items.map((u) => (
+        <li key={u.username} className="flex items-center gap-3">
+          <div className="h-9 w-9 overflow-hidden rounded-full bg-neutral-800 ring-1 ring-white/10">
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img src={u.avatarUrl ?? "/avatar-placeholder.png"} alt={u.username} className="h-full w-full object-cover" />
+          </div>
+          <div className="min-w-0">
+            <Link href={`/u/${u.username}`} className="font-medium hover:underline truncate block">
+              {u.displayName ?? u.username}
+            </Link>
+            <div className="text-xs text-neutral-500">@{u.username}</div>
+          </div>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/components/ui/Modal.tsx
+++ b/src/components/ui/Modal.tsx
@@ -1,0 +1,30 @@
+"use client";
+import { useEffect } from "react";
+
+export default function Modal({
+  open, onClose, title, children,
+}: { open: boolean; onClose: () => void; title?: string; children: React.ReactNode }) {
+
+  useEffect(() => {
+    const onEsc = (e: KeyboardEvent) => e.key === "Escape" && onClose();
+    document.addEventListener("keydown", onEsc);
+    return () => document.removeEventListener("keydown", onEsc);
+  }, [onClose]);
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-[60]">
+      <div className="absolute inset-0 bg-black/60" onClick={onClose} />
+      <div className="absolute inset-0 grid place-items-center p-4">
+        <div className="w-full max-w-md rounded-2xl border border-white/10 bg-neutral-900 shadow-lg">
+          <div className="flex items-center justify-between px-4 py-3 border-b border-white/10">
+            <h3 className="font-semibold">{title}</h3>
+            <button onClick={onClose} className="text-sm text-neutral-400 hover:text-neutral-200">Kapat</button>
+          </div>
+          <div className="p-4">{children}</div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/types/profile.ts
+++ b/src/lib/types/profile.ts
@@ -73,24 +73,33 @@ export interface ProfilePublicDto {
     userId: number;
     username: string;
     displayName?: string;
-    bio?: string;
+    bio?: string | null;
     avatarUrl?: string;
     bannerUrl?: string;
-    location?: string;
-    websiteUrl?: string;
+    location?: string | null;
+    websiteUrl?: string | null;
     language?: string;
     isVerified?: boolean | null;
     isPublic?: boolean | null;
     createdAt?: string;
     updatedAt?: string;
     links?: ProfileLinkDto[];
-    stats?: ProfileStatsDto;
+    stats?: ProfileStatsDto | null;
     listings?: ListingResponseDto[];
+
+    /** Viewer context */
+    isFollowing?: boolean | null;
+    isFollowedByMe?: boolean | null;
 }
 
 export interface ProfileOwnerDto extends ProfilePublicDto {
     prefs?: ProfilePrefsDto;
     notificationSettings?: NotificationSettingsDto;
+
+    /** Duplicated for easier access */
+    followersCount?: number;
+    followingCount?: number;
+    listings?: ListingResponseDto[];
 }
 
 export interface ProfileUpdateRequest {
@@ -108,3 +117,19 @@ export type NotificationSettingsUpdateRequest = NotificationSettingsDto;
 
 export interface UsernameAvailabilityDto { available: boolean; }
 export interface UsernameSuggestionsDto { candidates: string[]; }
+
+export interface FollowUserDto {
+    id: number;
+    username: string;
+    displayName?: string;
+    avatarUrl?: string;
+    isVerified?: boolean | null;
+}
+
+export interface FollowListResponse {
+    items: FollowUserDto[];
+    page: number;
+    size: number;
+    totalElements: number;
+    totalPages: number;
+}


### PR DESCRIPTION
## Summary
- extend profile types with follower/following stats, viewer flags and follow list DTOs
- add follow/unfollow hooks and list queries with viewer-aware public profile
- introduce follow button, modal, follow lists, and make MyStats counts open lists

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any in NotificationsForm.tsx and PrefsForm.tsx)*
- `npx eslint src/lib/types/profile.ts src/lib/queries/profile.ts src/components/profile/FollowButton.tsx src/components/ui/Modal.tsx src/components/profile/FollowList.tsx src/components/me/MyStats.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b7697f24dc832e86e73f8d51701f60