### PR TITLE
feat: add follow and public profile UI

### DIFF
--- a/src/app/me/page.tsx
+++ b/src/app/me/page.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import { useMyProfile, useInitMyProfile } from "@/lib/queries/profile";
+import FollowPanel from "@/components/me/FollowPanel";
 
 import ProfileHeader from "@/components/me/ProfileHeader";
 import ProfileForm from "@/components/me/ProfileForm";
@@ -96,6 +97,12 @@ export default function MePage() {
 
                 {/* Sağ kolon */}
                 <div className="lg:col-span-1 grid gap-6">
+                    <FollowPanel
+                        username={me.username}
+                        followersCount={me.stats?.followersCount ?? me.followersCount}
+                        followingCount={me.stats?.followingCount ?? me.followingCount}
+                    />
+
                     <section className="rounded-2xl border border-neutral-800 bg-neutral-900/60 shadow-sm p-6">
                         <h2 className="text-xl font-semibold mb-4">Tercihler</h2>
                         <PrefsForm me={me} />

--- a/src/app/u/[username]/page.tsx
+++ b/src/app/u/[username]/page.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import React from "react";
+import Link from "next/link";
+import { useParams } from "next/navigation";
+import Modal from "@/components/ui/Modal";
+import FollowButton from "@/components/profile/FollowButton";
+import { FollowersList, FollowingList } from "@/components/profile/FollowList";
+import { useMyProfile } from "@/lib/queries/profile"; // sizde me hook farklı dosyada olabilir
+import { usePublicProfile } from "@/lib/queries/profile";
+
+export default function PublicProfilePage() {
+  const { username } = useParams<{ username: string }>();
+  const me = useMyProfile?.().data; // me hook'unuz nasıl export ediliyorsa öyle kullanın
+  const { data: p, isLoading, isError } = usePublicProfile(username, me?.userId);
+
+  const [open, setOpen] = React.useState<null | "followers" | "following">(null);
+
+  if (isLoading) return <div className="mx-auto max-w-4xl px-4 py-10 text-sm text-neutral-400">Yükleniyor…</div>;
+  if (isError || !p) {
+    return (
+      <div className="mx-auto max-w-3xl px-4 py-16 grid gap-4">
+        <h1 className="text-2xl font-bold">Profil bulunamadı</h1>
+        <Link href="/" className="text-sm text-neutral-400 hover:text-neutral-200">← Anasayfa</Link>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto max-w-4xl px-4 py-6 grid gap-6">
+      {/* breadcrumbs */}
+      <nav className="text-sm">
+        <Link href="/" className="text-sky-400 hover:underline">Anasayfa</Link>
+        <span className="mx-2 text-neutral-500">/</span>
+        <span className="text-neutral-300">@{p.username}</span>
+      </nav>
+
+      {/* header */}
+      <section className="rounded-2xl border border-white/10 bg-neutral-900/60 shadow-sm p-0 overflow-hidden">
+        <div className="relative">
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src={p.bannerUrl ?? "/banner-placeholder.jpg"}
+            alt="banner"
+            className="h-40 w-full object-cover"
+          />
+        </div>
+
+        <div className="p-4 sm:p-6 flex items-center justify-between">
+          <div className="flex items-center gap-4">
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src={p.avatarUrl ?? "/avatar-placeholder.png"}
+              alt={p.username}
+              className="h-20 w-20 rounded-xl ring-2 ring-white object-cover -mt-12 bg-white"
+            />
+            <div>
+              <h1 className="text-xl font-extrabold">{p.displayName ?? p.username}</h1>
+              <div className="text-sm text-neutral-400">@{p.username}</div>
+            </div>
+          </div>
+
+          {me?.username !== p.username && (
+            <FollowButton username={p.username} initiallyFollowing={p.isFollowing} />
+          )}
+        </div>
+      </section>
+
+      {/* stats */}
+      <section className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+        <button
+          className="rounded-xl border border-white/10 p-4 bg-neutral-900 text-center shadow-sm hover:shadow-md"
+          onClick={() => setOpen("followers")}
+        >
+          <div className="text-2xl font-extrabold">{p.stats?.followersCount ?? 0}</div>
+          <div className="text-xs text-neutral-400">Takipçi</div>
+        </button>
+        <button
+          className="rounded-xl border border-white/10 p-4 bg-neutral-900 text-center shadow-sm hover:shadow-md"
+          onClick={() => setOpen("following")}
+        >
+          <div className="text-2xl font-extrabold">{p.stats?.followingCount ?? 0}</div>
+          <div className="text-xs text-neutral-400">Takip</div>
+        </button>
+      </section>
+
+      {/* bio */}
+      <section className="rounded-2xl border border-white/10 bg-neutral-900/60 shadow-sm p-5">
+        <h2 className="text-lg font-semibold mb-2">Hakkında</h2>
+        <p className="text-sm text-neutral-300 whitespace-pre-wrap">{p.bio ?? "—"}</p>
+        <div className="mt-3 grid gap-2 text-sm text-neutral-400">
+          {p.location && <div><span className="text-neutral-500">Konum:</span> {p.location}</div>}
+          {p.websiteUrl && (
+            <div>
+              <span className="text-neutral-500">Web:</span>{" "}
+              <a href={p.websiteUrl} target="_blank" className="text-sky-400 hover:underline">
+                {p.websiteUrl}
+              </a>
+            </div>
+          )}
+        </div>
+      </section>
+
+      {/* modal’lar */}
+      <Modal open={open === "followers"} onClose={() => setOpen(null)} title="Takipçiler">
+        <FollowersList username={p.username} />
+      </Modal>
+      <Modal open={open === "following"} onClose={() => setOpen(null)} title="Takip Edilenler">
+        <FollowingList username={p.username} />
+      </Modal>
+    </div>
+  );
+}

--- a/src/components/auction/AuctionCard.tsx
+++ b/src/components/auction/AuctionCard.tsx
@@ -40,6 +40,18 @@ export default function AuctionCard({ a }: { a: AuctionListItemDto }) {
             {highest === "-" ? "-" : `${Number(highest).toFixed(2)} ${a.currency}`}
           </span>
         </div>
+        {a.sellerUsername && (
+          <div className="mt-2 text-xs text-neutral-400">
+            Satıcı:{" "}
+            <Link
+              href={`/u/${a.sellerUsername}`}
+              onClick={(e) => e.stopPropagation()}
+              className="text-sky-400 hover:underline"
+            >
+              @{a.sellerUsername}
+            </Link>
+          </div>
+        )}
       </div>
     </Link>
   );

--- a/src/components/listings/ListingCard.tsx
+++ b/src/components/listings/ListingCard.tsx
@@ -30,6 +30,18 @@ export default function ListingCard({ it }: { it: ListingResponseDto }) {
                     </span>
                     {it.location && <span className="text-xs text-neutral-400">{it.location}</span>}
                 </div>
+                {it.seller?.username && (
+                    <div className="mt-1 text-xs text-neutral-400">
+                        Satıcı:{" "}
+                        <Link
+                            href={`/u/${it.seller.username}`}
+                            onClick={(e) => e.stopPropagation()}
+                            className="text-sky-400 hover:underline"
+                        >
+                            @{it.seller.username}
+                        </Link>
+                    </div>
+                )}
             </div>
         </Link>
     );

--- a/src/components/me/FollowPanel.tsx
+++ b/src/components/me/FollowPanel.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import React from "react";
+import Modal from "@/components/ui/Modal";
+import { FollowersList, FollowingList } from "@/components/profile/FollowList";
+
+export default function FollowPanel({
+  username,
+  followersCount,
+  followingCount,
+}: {
+  username: string;
+  followersCount?: number;
+  followingCount?: number;
+}) {
+  const [open, setOpen] = React.useState<null | "followers" | "following">(null);
+
+  return (
+    <>
+      <section className="rounded-2xl border border-neutral-800 bg-neutral-900/60 shadow-sm p-6">
+        <h2 className="text-xl font-semibold mb-4">Takip</h2>
+        <div className="grid grid-cols-2 gap-3">
+          <button
+            onClick={() => setOpen("followers")}
+            className="rounded-xl border border-white/10 p-4 text-center hover:bg-white/5"
+          >
+            <div className="text-2xl font-extrabold">{followersCount ?? 0}</div>
+            <div className="text-xs text-neutral-400">Takipçi</div>
+          </button>
+          <button
+            onClick={() => setOpen("following")}
+            className="rounded-xl border border-white/10 p-4 text-center hover:bg-white/5"
+          >
+            <div className="text-2xl font-extrabold">{followingCount ?? 0}</div>
+            <div className="text-xs text-neutral-400">Takip</div>
+          </button>
+        </div>
+      </section>
+
+      <Modal open={open === "followers"} onClose={() => setOpen(null)} title="Takipçilerim">
+        <FollowersList username={username} />
+      </Modal>
+      <Modal open={open === "following"} onClose={() => setOpen(null)} title="Takip Ettiklerim">
+        <FollowingList username={username} />
+      </Modal>
+    </>
+  );
+}

--- a/src/components/me/NotificationsForm.tsx
+++ b/src/components/me/NotificationsForm.tsx
@@ -89,7 +89,11 @@ export default function NotificationsForm({ me }: Props) {
                     Bildirimleri Kaydet
                 </button>
                 {saved && <span className="text-xs px-2 py-1 rounded bg-emerald-600/20 text-emerald-300">Kaydedildi</span>}
-                {m.isError && <span className="text-xs px-2 py-1 rounded bg-red-600/20 text-red-300">Hata: {(m.error as any)?.message ?? "Kaydedilemedi"}</span>}
+                {m.isError && (
+                    <span className="text-xs px-2 py-1 rounded bg-red-600/20 text-red-300">
+                        Hata: {m.error instanceof Error ? m.error.message : "Kaydedilemedi"}
+                    </span>
+                )}
             </div>
         </form>
     );

--- a/src/components/me/PrefsForm.tsx
+++ b/src/components/me/PrefsForm.tsx
@@ -73,7 +73,11 @@ export default function PrefsForm({ me }: Props) {
                     Tercihleri Kaydet
                 </button>
                 {saved && <span className="text-xs px-2 py-1 rounded bg-emerald-600/20 text-emerald-300">Kaydedildi</span>}
-                {m.isError && <span className="text-xs px-2 py-1 rounded bg-red-600/20 text-red-300">Hata: {(m.error as any)?.message ?? "Kaydedilemedi"}</span>}
+                {m.isError && (
+                    <span className="text-xs px-2 py-1 rounded bg-red-600/20 text-red-300">
+                        Hata: {m.error instanceof Error ? m.error.message : "Kaydedilemedi"}
+                    </span>
+                )}
             </div>
         </form>
     );

--- a/src/components/profile/FollowButton.tsx
+++ b/src/components/profile/FollowButton.tsx
@@ -1,48 +1,37 @@
 "use client";
-import { useState } from "react";
 import { useFollow, useUnfollow } from "@/lib/queries/profile";
-import { useToast } from "@/components/ui/toast";
 
-type Props = {
+export default function FollowButton({
+  username,
+  initiallyFollowing,
+}: {
   username: string;
   initiallyFollowing?: boolean | null;
-  compact?: boolean; // küçük badge tarzı
-};
-
-export default function FollowButton({ username, initiallyFollowing, compact }: Props) {
-  const [isFollowing, setIsFollowing] = useState(!!initiallyFollowing);
+}) {
   const follow = useFollow(username);
   const unfollow = useUnfollow(username);
-  const { push } = useToast();
 
-  const toggle = () => {
-    if (isFollowing) {
-      unfollow.mutate(undefined, {
-        onSuccess: () => { setIsFollowing(false); push({ type:"success", title:"Takipten çıkıldı" }); },
-        onError: (e) => push({ type:"error", title:"İşlem başarısız", description:String(e) }),
-      });
-    } else {
-      follow.mutate(undefined, {
-        onSuccess: () => { setIsFollowing(true); push({ type:"success", title:"Takip edildi" }); },
-        onError: (e) => push({ type:"error", title:"İşlem başarısız", description:String(e) }),
-      });
-    }
-  };
+  const isLoading = follow.isPending || unfollow.isPending;
+  const isFollowing =
+    unfollow.isPending ? true :
+    follow.isPending ? false :
+    !!initiallyFollowing;
 
-  const loading = follow.isPending || unfollow.isPending;
-
-  return (
+  return isFollowing ? (
     <button
-      onClick={toggle}
-      disabled={loading}
-      className={
-        isFollowing
-          ? "rounded-lg px-3 py-1.5 text-sm font-semibold bg-neutral-800 text-white hover:bg-neutral-700 disabled:opacity-60"
-          : "rounded-lg px-3 py-1.5 text-sm font-semibold text-white bg-gradient-to-r from-sky-400 to-blue-600 hover:opacity-95 disabled:opacity-60"
-      }
-      aria-pressed={isFollowing}
+      onClick={() => unfollow.mutate()}
+      disabled={isLoading}
+      className="rounded-lg border border-white/20 px-3 py-1.5 text-sm font-semibold hover:bg-white/10 disabled:opacity-60"
     >
-      {loading ? "…" : isFollowing ? (compact ? "Takip" : "Takiptesin") : (compact ? "Takip Et" : "Takip Et")}
+      Takipten Çık
+    </button>
+  ) : (
+    <button
+      onClick={() => follow.mutate()}
+      disabled={isLoading}
+      className="rounded-lg bg-gradient-to-r from-sky-400 to-blue-600 px-3 py-1.5 text-sm font-semibold text-white disabled:opacity-60"
+    >
+      Takip Et
     </button>
   );
 }

--- a/src/components/profile/FollowList.tsx
+++ b/src/components/profile/FollowList.tsx
@@ -1,35 +1,42 @@
 "use client";
+
 import Link from "next/link";
 import { useFollowers, useFollowing } from "@/lib/queries/profile";
 
 export function FollowersList({ username }: { username: string }) {
-  const { data } = useFollowers(username, 0, 50);
-  if (!data) return null;
-  return <List items={data.items} empty="Henüz takipçi yok." />;
+  const { data, isLoading, isError } = useFollowers(username);
+  if (isLoading) return <p className="text-sm text-neutral-400">Yükleniyor…</p>;
+  if (isError) return <p className="text-sm text-red-400">Takipçiler alınamadı.</p>;
+
+  if (!data?.items?.length) return <p className="text-sm text-neutral-400">Takipçi yok.</p>;
+  return <UserList items={data.items} />;
 }
 
 export function FollowingList({ username }: { username: string }) {
-  const { data } = useFollowing(username, 0, 50);
-  if (!data) return null;
-  return <List items={data.items} empty="Henüz kimseyi takip etmiyor." />;
+  const { data, isLoading, isError } = useFollowing(username);
+  if (isLoading) return <p className="text-sm text-neutral-400">Yükleniyor…</p>;
+  if (isError) return <p className="text-sm text-red-400">Takip edilenler alınamadı.</p>;
+
+  if (!data?.items?.length) return <p className="text-sm text-neutral-400">Kimseyi takip etmiyorsun.</p>;
+  return <UserList items={data.items} />;
 }
 
-function List({ items, empty }: { items: { username: string; displayName?: string; avatarUrl?: string; isVerified?: boolean | null }[]; empty: string }) {
-  if (!items.length) return <p className="text-sm text-neutral-400">{empty}</p>;
+function UserList({ items }: { items: {username:string;displayName?:string|null;avatarUrl?:string|null;isVerified?:boolean|null}[] }) {
   return (
-    <ul className="grid gap-3">
+    <ul className="grid gap-2">
       {items.map((u) => (
-        <li key={u.username} className="flex items-center gap-3">
-          <div className="h-9 w-9 overflow-hidden rounded-full bg-neutral-800 ring-1 ring-white/10">
+        <li key={u.username} className="flex items-center justify-between rounded-xl border border-white/10 p-2">
+          <div className="flex items-center gap-3">
             {/* eslint-disable-next-line @next/next/no-img-element */}
-            <img src={u.avatarUrl ?? "/avatar-placeholder.png"} alt={u.username} className="h-full w-full object-cover" />
+            <img src={u.avatarUrl ?? "/avatar-placeholder.png"} alt={u.username} className="h-9 w-9 rounded-lg object-cover ring-1 ring-white/10"/>
+            <div>
+              <Link href={`/u/${u.username}`} className="font-semibold hover:underline">
+                {u.displayName ?? u.username}
+              </Link>
+              <div className="text-xs text-neutral-400">@{u.username}</div>
+            </div>
           </div>
-          <div className="min-w-0">
-            <Link href={`/u/${u.username}`} className="font-medium hover:underline truncate block">
-              {u.displayName ?? u.username}
-            </Link>
-            <div className="text-xs text-neutral-500">@{u.username}</div>
-          </div>
+          <Link href={`/u/${u.username}`} className="text-xs text-sky-400 hover:underline">Profili gör →</Link>
         </li>
       ))}
     </ul>

--- a/src/components/ui/Modal.tsx
+++ b/src/components/ui/Modal.tsx
@@ -1,29 +1,31 @@
 "use client";
-import { useEffect } from "react";
+import React from "react";
 
 export default function Modal({
-  open, onClose, title, children,
-}: { open: boolean; onClose: () => void; title?: string; children: React.ReactNode }) {
-
-  useEffect(() => {
-    const onEsc = (e: KeyboardEvent) => e.key === "Escape" && onClose();
-    document.addEventListener("keydown", onEsc);
-    return () => document.removeEventListener("keydown", onEsc);
-  }, [onClose]);
-
+  open,
+  onClose,
+  title,
+  children,
+}: {
+  open: boolean;
+  onClose: () => void;
+  title?: string;
+  children: React.ReactNode;
+}) {
   if (!open) return null;
-
   return (
-    <div className="fixed inset-0 z-[60]">
-      <div className="absolute inset-0 bg-black/60" onClick={onClose} />
-      <div className="absolute inset-0 grid place-items-center p-4">
-        <div className="w-full max-w-md rounded-2xl border border-white/10 bg-neutral-900 shadow-lg">
-          <div className="flex items-center justify-between px-4 py-3 border-b border-white/10">
-            <h3 className="font-semibold">{title}</h3>
-            <button onClick={onClose} className="text-sm text-neutral-400 hover:text-neutral-200">Kapat</button>
-          </div>
-          <div className="p-4">{children}</div>
+    <div className="fixed inset-0 z-50">
+      <div
+        className="absolute inset-0 bg-black/60 backdrop-blur-sm"
+        onClick={onClose}
+        aria-hidden
+      />
+      <div className="absolute left-1/2 top-1/2 w-[95vw] max-w-lg -translate-x-1/2 -translate-y-1/2 rounded-2xl border border-white/10 bg-neutral-900 p-4 shadow-xl">
+        <div className="mb-3 flex items-center justify-between">
+          <h3 className="text-base font-semibold">{title}</h3>
+          <button onClick={onClose} className="text-sm text-neutral-400 hover:text-neutral-200">Kapat</button>
         </div>
+        <div className="max-h-[60vh] overflow-auto">{children}</div>
       </div>
     </div>
   );

--- a/src/lib/types/auction.ts
+++ b/src/lib/types/auction.ts
@@ -15,6 +15,7 @@ export type AuctionListItemDto = {
   endsAt: string;              // ISO
   // opsiyonel görsel
   coverUrl?: string | null;
+  sellerUsername?: string | null;
 };
 
 export type AuctionResponseDto = {

--- a/src/lib/types/profile.ts
+++ b/src/lib/types/profile.ts
@@ -72,13 +72,13 @@ export interface ProfilePublicDto {
     id: number;
     userId: number;
     username: string;
-    displayName?: string;
+    displayName?: string | null;
     bio?: string | null;
-    avatarUrl?: string;
-    bannerUrl?: string;
+    avatarUrl?: string | null;
+    bannerUrl?: string | null;
     location?: string | null;
     websiteUrl?: string | null;
-    language?: string;
+    language?: string | null;
     isVerified?: boolean | null;
     isPublic?: boolean | null;
     createdAt?: string;
@@ -118,18 +118,18 @@ export type NotificationSettingsUpdateRequest = NotificationSettingsDto;
 export interface UsernameAvailabilityDto { available: boolean; }
 export interface UsernameSuggestionsDto { candidates: string[]; }
 
-export interface FollowUserDto {
-    id: number;
+export type FollowUserDto = {
+    id: number;            // profileId
     username: string;
-    displayName?: string;
-    avatarUrl?: string;
+    displayName: string | null;
+    avatarUrl?: string | null;
     isVerified?: boolean | null;
-}
+};
 
-export interface FollowListResponse {
+export type FollowListResponse = {
     items: FollowUserDto[];
     page: number;
     size: number;
     totalElements: number;
     totalPages: number;
-}
+};


### PR DESCRIPTION
## Summary
- implement follow hooks and types for public profiles
- add FollowButton, FollowList, and modal components
- expose public profile page and follow panel on user dashboard
- link seller names on auction and listing cards

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build` *(fails: Type error in collections/[slug]/page.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68b86d78722c832e8a29a000ecd2f348