### PR TITLE
Fix profile queries and listing card links

### DIFF
--- a/src/components/listings/ListingCard.tsx
+++ b/src/components/listings/ListingCard.tsx
@@ -1,12 +1,14 @@
 "use client";
 
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import type { ListingResponseDto } from "@/lib/types/listing";
 
 export default function ListingCard({ it }: { it: ListingResponseDto }) {
     const img = it.images?.[0]?.url ?? "/listing-placeholder.jpg";
     const isTrade = it.type === "TRADE";
     const badge = isTrade ? "Takas" : (it.price ? `${formatMoney(it.price, it.currency)}` : "Satış");
+    const router = useRouter();
 
     return (
         <Link href={`/listings/${it.id}`} className="group block overflow-hidden rounded-xl border border-white/10 bg-neutral-900 hover:border-white/20">
@@ -33,13 +35,15 @@ export default function ListingCard({ it }: { it: ListingResponseDto }) {
                 {it.seller?.username && (
                     <div className="mt-1 text-xs text-neutral-400">
                         Satıcı:{" "}
-                        <Link
-                            href={`/u/${it.seller.username}`}
-                            onClick={(e) => e.stopPropagation()}
-                            className="text-sky-400 hover:underline"
+                        <span
+                            onClick={(e) => {
+                                e.stopPropagation();
+                                router.push(`/u/${it.seller!.username}`);
+                            }}
+                            className="cursor-pointer text-sky-400 hover:underline"
                         >
                             @{it.seller.username}
-                        </Link>
+                        </span>
                     </div>
                 )}
             </div>

--- a/src/lib/queries/profile.ts
+++ b/src/lib/queries/profile.ts
@@ -11,21 +11,22 @@ import type {
 } from "@/lib/types/profile";
 
 // Fetch helpers for public profile and follow APIs
+// These use the axios `api` instance so that requests are sent to the backend
+// base URL instead of the Next.js dev server. Previously `fetch` was called
+// with relative paths which resulted in 404 responses from the UI when the
+// backend actually had the data.
 async function getJSON<T>(url: string): Promise<T> {
-    const r = await fetch(url, { credentials: "include" });
-    if (!r.ok) throw new Error(await r.text());
-    return r.json();
+    const r = await api.get<T>(url);
+    return r.data;
 }
+
 async function call(method: "POST" | "DELETE", url: string, body?: unknown) {
-    const r = await fetch(url, {
+    const r = await api.request({
+        url,
         method,
-        credentials: "include",
-        headers: body ? { "Content-Type": "application/json" } : undefined,
-        body: body ? JSON.stringify(body) : undefined,
+        data: body,
     });
-    if (!r.ok) throw new Error(await r.text());
-    if (r.status === 204) return null;
-    try { return await r.json(); } catch { return null; }
+    return r.status === 204 ? null : r.data;
 }
 
 export const qk = {


### PR DESCRIPTION
## Summary
- use axios api instance in profile query helpers so requests reach backend API instead of Next.js server
- replace nested anchor in listing cards with span + router navigation to avoid hydration errors

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b894246bfc832ea882958d1940f5ad