### PR TITLE
Improve profile pages and navigation

### DIFF
--- a/src/app/u/[username]/page.tsx
+++ b/src/app/u/[username]/page.tsx
@@ -6,6 +6,7 @@ import { useParams } from "next/navigation";
 import Modal from "@/components/ui/Modal";
 import FollowButton from "@/components/profile/FollowButton";
 import { FollowersList, FollowingList } from "@/components/profile/FollowList";
+import ListingCard from "@/components/listings/ListingCard";
 import { useMyProfile } from "@/lib/queries/profile"; // sizde me hook farklı dosyada olabilir
 import { usePublicProfile } from "@/lib/queries/profile";
 
@@ -25,6 +26,8 @@ export default function PublicProfilePage() {
       </div>
     );
   }
+
+  const s = p.stats ?? {};
 
   return (
     <div className="mx-auto max-w-4xl px-4 py-6 grid gap-6">
@@ -67,21 +70,24 @@ export default function PublicProfilePage() {
       </section>
 
       {/* stats */}
-      <section className="grid grid-cols-2 sm:grid-cols-4 gap-3">
-        <button
-          className="rounded-xl border border-white/10 p-4 bg-neutral-900 text-center shadow-sm hover:shadow-md"
-          onClick={() => setOpen("followers")}
-        >
-          <div className="text-2xl font-extrabold">{p.stats?.followersCount ?? 0}</div>
-          <div className="text-xs text-neutral-400">Takipçi</div>
-        </button>
-        <button
-          className="rounded-xl border border-white/10 p-4 bg-neutral-900 text-center shadow-sm hover:shadow-md"
-          onClick={() => setOpen("following")}
-        >
-          <div className="text-2xl font-extrabold">{p.stats?.followingCount ?? 0}</div>
-          <div className="text-xs text-neutral-400">Takip</div>
-        </button>
+      <section className="grid grid-cols-2 sm:grid-cols-5 gap-3">
+        {[
+          { key: "listingsActive", label: "Aktif İlan", value: s.listingsActiveCount ?? 0 },
+          { key: "listingsTotal", label: "Toplam İlan", value: s.listingsTotalCount ?? 0 },
+          { key: "followers", label: "Takipçi", value: s.followersCount ?? 0, clickable: true },
+          { key: "following", label: "Takip", value: s.followingCount ?? 0, clickable: true },
+          { key: "responseRate", label: "Cevap Oranı", value: `${s.responseRate ?? 0}%` },
+        ].map((c) => (
+          <button
+            key={c.key}
+            className="rounded-xl border border-white/10 p-4 bg-neutral-900 text-center shadow-sm hover:shadow-md disabled:cursor-default"
+            onClick={() => c.clickable && setOpen(c.key as "followers" | "following")}
+            disabled={!c.clickable}
+          >
+            <div className="text-2xl font-extrabold">{c.value}</div>
+            <div className="text-xs text-neutral-400">{c.label}</div>
+          </button>
+        ))}
       </section>
 
       {/* bio */}
@@ -90,6 +96,7 @@ export default function PublicProfilePage() {
         <p className="text-sm text-neutral-300 whitespace-pre-wrap">{p.bio ?? "—"}</p>
         <div className="mt-3 grid gap-2 text-sm text-neutral-400">
           {p.location && <div><span className="text-neutral-500">Konum:</span> {p.location}</div>}
+          {p.language && <div><span className="text-neutral-500">Dil:</span> {p.language}</div>}
           {p.websiteUrl && (
             <div>
               <span className="text-neutral-500">Web:</span>{" "}
@@ -98,8 +105,28 @@ export default function PublicProfilePage() {
               </a>
             </div>
           )}
+          {p.links?.map((l) => (
+            <div key={l.id}>
+              <span className="text-neutral-500">{l.label ?? l.type}:</span>{" "}
+              <a href={l.url} target="_blank" className="text-sky-400 hover:underline">
+                {l.url}
+              </a>
+            </div>
+          ))}
         </div>
       </section>
+
+      {/* listings */}
+      {p.listings?.length ? (
+        <section className="rounded-2xl border border-white/10 bg-neutral-900/60 shadow-sm p-5">
+          <h2 className="text-lg font-semibold mb-4">İlanlar</h2>
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+            {p.listings.map((l) => (
+              <ListingCard key={l.id} it={l} />
+            ))}
+          </div>
+        </section>
+      ) : null}
 
       {/* modal’lar */}
       <Modal open={open === "followers"} onClose={() => setOpen(null)} title="Takipçiler">

--- a/src/components/auction/AuctionCard.tsx
+++ b/src/components/auction/AuctionCard.tsx
@@ -1,5 +1,7 @@
 "use client";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useMyProfile } from "@/lib/queries/profile";
 import { AuctionListItemDto } from "@/lib/types/auction";
 import { formatCountdown } from "@/lib/utils/time";
 import { trAuctionStatus } from "@/lib/utils/i18n";
@@ -7,6 +9,8 @@ import { trAuctionStatus } from "@/lib/utils/i18n";
 export default function AuctionCard({ a }: { a: AuctionListItemDto }) {
   const highest = a.highestBidAmount ?? "-";
   const cover = a.coverUrl ?? `https://picsum.photos/seed/auction${a.id}/1200/800`;
+  const router = useRouter();
+  const { data: me } = useMyProfile();
 
   return (
     <Link
@@ -43,13 +47,16 @@ export default function AuctionCard({ a }: { a: AuctionListItemDto }) {
         {a.sellerUsername && (
           <div className="mt-2 text-xs text-neutral-400">
             Satıcı:{" "}
-            <Link
-              href={`/u/${a.sellerUsername}`}
-              onClick={(e) => e.stopPropagation()}
-              className="text-sky-400 hover:underline"
+            <span
+              onClick={(e) => {
+                e.stopPropagation();
+                const u = a.sellerUsername!;
+                router.push(me?.username === u ? "/me" : `/u/${u}`);
+              }}
+              className="cursor-pointer text-sky-400 hover:underline"
             >
               @{a.sellerUsername}
-            </Link>
+            </span>
           </div>
         )}
       </div>

--- a/src/components/listings/ListingCard.tsx
+++ b/src/components/listings/ListingCard.tsx
@@ -1,12 +1,16 @@
 "use client";
 
 import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useMyProfile } from "@/lib/queries/profile";
 import type { ListingResponseDto } from "@/lib/types/listing";
 
 export default function ListingCard({ it }: { it: ListingResponseDto }) {
     const img = it.images?.[0]?.url ?? "/listing-placeholder.jpg";
     const isTrade = it.type === "TRADE";
     const badge = isTrade ? "Takas" : (it.price ? `${formatMoney(it.price, it.currency)}` : "Satış");
+    const router = useRouter();
+    const { data: me } = useMyProfile();
 
     return (
         <Link href={`/listings/${it.id}`} className="group block overflow-hidden rounded-xl border border-white/10 bg-neutral-900 hover:border-white/20">
@@ -33,13 +37,16 @@ export default function ListingCard({ it }: { it: ListingResponseDto }) {
                 {it.seller?.username && (
                     <div className="mt-1 text-xs text-neutral-400">
                         Satıcı:{" "}
-                        <Link
-                            href={`/u/${it.seller.username}`}
-                            onClick={(e) => e.stopPropagation()}
-                            className="text-sky-400 hover:underline"
+                        <span
+                            onClick={(e) => {
+                                e.stopPropagation();
+                                const u = it.seller!.username;
+                                router.push(me?.username === u ? "/me" : `/u/${u}`);
+                            }}
+                            className="cursor-pointer text-sky-400 hover:underline"
                         >
                             @{it.seller.username}
-                        </Link>
+                        </span>
                     </div>
                 )}
             </div>

--- a/src/components/me/MyListingsGrid.tsx
+++ b/src/components/me/MyListingsGrid.tsx
@@ -1,37 +1,15 @@
+import ListingCard from "@/components/listings/ListingCard";
 import type { ProfileOwnerDto } from "@/lib/types/profile";
 
 export default function MyListingsGrid({ me }: { me: ProfileOwnerDto }) {
     const items = me.listings ?? [];
-    if (!items.length) return null;
+    if (!items.length) return <p className="text-sm text-neutral-400">Henüz ilan yok.</p>;
 
     return (
-        <section className="rounded-2xl border border-neutral-200 dark:border-white/10 p-5 bg-white dark:bg-neutral-900 shadow-sm">
-            <h3 className="text-lg font-bold mb-4">İlanlarım</h3>
-            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
-                {items.map((t) => (
-                    <article key={t.id} className="group overflow-hidden rounded-2xl border border-neutral-200 dark:border-white/10 bg-white dark:bg-neutral-900 shadow-sm hover:shadow-md transition-shadow">
-                        <div className="relative">
-                            <img
-                                src={t.images?.[0]?.url ?? "https://picsum.photos/seed/fallback/800/600"}
-                                alt={t.title}
-                                className="h-40 w-full object-cover transition-transform duration-300 group-hover:scale-[1.03]"
-                            />
-                            {t.brandName && (
-                                <span className="absolute top-2 left-2 rounded-md bg-gradient-to-r from-sky-400 to-blue-600 text-white text-xs font-bold px-2 py-1 shadow-sm ring-1 ring-white/30">
-                  {t.brandName}
-                </span>
-                            )}
-                        </div>
-                        <div className="p-4">
-                            <h4 className="font-bold line-clamp-1">{t.title}</h4>
-                            <p className="text-xs text-neutral-500 dark:text-neutral-400 line-clamp-1">
-                                {t.modelName ?? t.seriesName ?? t.theme ?? ""}
-                            </p>
-                            <p className="mt-1 text-sm">{t.price ? `${t.price} ${t.currency ?? ""}` : ""}</p>
-                        </div>
-                    </article>
-                ))}
-            </div>
-        </section>
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+            {items.map((t) => (
+                <ListingCard key={t.id} it={t} />
+            ))}
+        </div>
     );
 }

--- a/src/components/profile/FollowButton.tsx
+++ b/src/components/profile/FollowButton.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { useState, useEffect } from "react";
 import { useFollow, useUnfollow } from "@/lib/queries/profile";
 
 export default function FollowButton({
@@ -11,15 +12,14 @@ export default function FollowButton({
   const follow = useFollow(username);
   const unfollow = useUnfollow(username);
 
+  const [isFollowing, setIsFollowing] = useState(!!initiallyFollowing);
+  useEffect(() => setIsFollowing(!!initiallyFollowing), [initiallyFollowing]);
+
   const isLoading = follow.isPending || unfollow.isPending;
-  const isFollowing =
-    unfollow.isPending ? true :
-    follow.isPending ? false :
-    !!initiallyFollowing;
 
   return isFollowing ? (
     <button
-      onClick={() => unfollow.mutate()}
+      onClick={() => unfollow.mutate(undefined, { onSuccess: () => setIsFollowing(false) })}
       disabled={isLoading}
       className="rounded-lg border border-white/20 px-3 py-1.5 text-sm font-semibold hover:bg-white/10 disabled:opacity-60"
     >
@@ -27,7 +27,7 @@ export default function FollowButton({
     </button>
   ) : (
     <button
-      onClick={() => follow.mutate()}
+      onClick={() => follow.mutate(undefined, { onSuccess: () => setIsFollowing(true) })}
       disabled={isLoading}
       className="rounded-lg bg-gradient-to-r from-sky-400 to-blue-600 px-3 py-1.5 text-sm font-semibold text-white disabled:opacity-60"
     >

--- a/src/components/profile/FollowList.tsx
+++ b/src/components/profile/FollowList.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { useFollowers, useFollowing } from "@/lib/queries/profile";
+import { useMyProfile, useFollowers, useFollowing } from "@/lib/queries/profile";
 
 export function FollowersList({ username }: { username: string }) {
   const { data, isLoading, isError } = useFollowers(username);
@@ -22,23 +22,27 @@ export function FollowingList({ username }: { username: string }) {
 }
 
 function UserList({ items }: { items: {username:string;displayName?:string|null;avatarUrl?:string|null;isVerified?:boolean|null}[] }) {
+  const { data: me } = useMyProfile();
   return (
     <ul className="grid gap-2">
-      {items.map((u) => (
-        <li key={u.username} className="flex items-center justify-between rounded-xl border border-white/10 p-2">
-          <div className="flex items-center gap-3">
-            {/* eslint-disable-next-line @next/next/no-img-element */}
-            <img src={u.avatarUrl ?? "/avatar-placeholder.png"} alt={u.username} className="h-9 w-9 rounded-lg object-cover ring-1 ring-white/10"/>
-            <div>
-              <Link href={`/u/${u.username}`} className="font-semibold hover:underline">
-                {u.displayName ?? u.username}
-              </Link>
-              <div className="text-xs text-neutral-400">@{u.username}</div>
+      {items.map((u) => {
+        const url = me?.username === u.username ? "/me" : `/u/${u.username}`;
+        return (
+          <li key={u.username} className="flex items-center justify-between rounded-xl border border-white/10 p-2">
+            <div className="flex items-center gap-3">
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img src={u.avatarUrl ?? "/avatar-placeholder.png"} alt={u.username} className="h-9 w-9 rounded-lg object-cover ring-1 ring-white/10"/>
+              <div>
+                <Link href={url} className="font-semibold hover:underline">
+                  {u.displayName ?? u.username}
+                </Link>
+                <div className="text-xs text-neutral-400">@{u.username}</div>
+              </div>
             </div>
-          </div>
-          <Link href={`/u/${u.username}`} className="text-xs text-sky-400 hover:underline">Profili gör →</Link>
-        </li>
-      ))}
+            <Link href={url} className="text-xs text-sky-400 hover:underline">Profili gör →</Link>
+          </li>
+        );
+      })}
     </ul>
   );
 }

--- a/src/lib/queries/profile.ts
+++ b/src/lib/queries/profile.ts
@@ -11,21 +11,22 @@ import type {
 } from "@/lib/types/profile";
 
 // Fetch helpers for public profile and follow APIs
+// These use the axios `api` instance so that requests are sent to the backend
+// base URL instead of the Next.js dev server. Previously `fetch` was called
+// with relative paths which resulted in 404 responses from the UI when the
+// backend actually had the data.
 async function getJSON<T>(url: string): Promise<T> {
-    const r = await fetch(url, { credentials: "include" });
-    if (!r.ok) throw new Error(await r.text());
-    return r.json();
+    const r = await api.get<T>(url);
+    return r.data;
 }
+
 async function call(method: "POST" | "DELETE", url: string, body?: unknown) {
-    const r = await fetch(url, {
+    const r = await api.request({
+        url,
         method,
-        credentials: "include",
-        headers: body ? { "Content-Type": "application/json" } : undefined,
-        body: body ? JSON.stringify(body) : undefined,
+        data: body,
     });
-    if (!r.ok) throw new Error(await r.text());
-    if (r.status === 204) return null;
-    try { return await r.json(); } catch { return null; }
+    return r.status === 204 ? null : r.data;
 }
 
 export const qk = {


### PR DESCRIPTION
## Summary
- redirect self user links to `/me` from listings, auctions, and follow lists
- expand public profile page with stats, contact details, and user listings
- fix follow button state handling and deduplicate listing sections on profile pages

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b894246bfc832ea882958d1940f5ad