### PR TITLE
fix: unwrap params in collection detail page

### DIFF
--- a/src/app/collections/[slug]/page.tsx
+++ b/src/app/collections/[slug]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { use, useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 
 const API_BASE = process.env.NEXT_PUBLIC_API_BASE ?? "http://localhost:8080";
@@ -46,11 +46,12 @@ export default function CollectionDetailPage({
   params,
   searchParams,
 }: {
-  params: { slug: string };
-  searchParams: { page?: string };
+  params: Promise<{ slug: string }>;
+  searchParams: Promise<{ page?: string }>;
 }) {
-  const slug = params.slug;
-  const pageIdx = Math.max(0, parseInt(searchParams.page ?? "0", 10) || 0);
+  const { slug } = use(params);
+  const { page } = use(searchParams);
+  const pageIdx = Math.max(0, parseInt(page ?? "0", 10) || 0);
 
   const [data, setData] = useState<PageResponse | null>(null);
   const [loading, setLoading] = useState(true);


### PR DESCRIPTION
## Summary
- unwrap `params` and `searchParams` with `React.use` in collection detail page to align with Next.js dynamic API

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b9e95cf57c832eb0c61239b52e163b