### PR TITLE
refactor: refine modal and filter props

### DIFF
--- a/src/app/listings/page.tsx
+++ b/src/app/listings/page.tsx
@@ -28,7 +28,9 @@ export default function ListingsPage() {
 
             <ListingFilters
                 value={filters}
-                onChangeAction={(f) => setParams((s) => ({ ...s, ...f, page: 0 }))}
+                onChangeAction={(f: Filters) =>
+                    setParams((s) => ({ ...s, ...f, page: 0 }))
+                }
             />
 
             {isLoading && <div className="text-neutral-400">Yükleniyor…</div>}

--- a/src/components/listings/ListingFilters.tsx
+++ b/src/components/listings/ListingFilters.tsx
@@ -8,14 +8,16 @@ export type Filters = Pick<
   "type" | "priceMin" | "priceMax" | "sortBy" | "sortDir" | "size"
 >;
 
-export default function ListingFilters({
-  value,
-  onChangeAction,
-}: {
+interface ListingFiltersProps {
   value: Filters;
   /** Next 15: function prop adı ...Action olmalı */
   onChangeAction: (f: Filters) => void;
-}) {
+}
+
+export default function ListingFilters({
+  value,
+  onChangeAction,
+}: ListingFiltersProps) {
   const [local, setLocal] = useState<Filters>(value);
   useEffect(() => setLocal(value), [value]);
 

--- a/src/components/ui/Modal.tsx
+++ b/src/components/ui/Modal.tsx
@@ -1,18 +1,20 @@
 "use client";
 import React from "react";
 
-export default function Modal({
-  open,
-  onCloseAction,
-  title,
-  children,
-}: {
+interface ModalProps {
   open: boolean;
   /** Next 15: function prop adı ...Action olmalı */
   onCloseAction: () => void;
   title?: string;
   children: React.ReactNode;
-}) {
+}
+
+export default function Modal({
+  open,
+  onCloseAction,
+  title,
+  children,
+}: ModalProps) {
   if (!open) return null;
   return (
     <div className="fixed inset-0 z-50">


### PR DESCRIPTION
## Summary
- define explicit ModalProps and ListingFiltersProps to ensure function props end with Action for Next 15 compliance
- annotate listing page filter callback with typed Filters

## Testing
- `npm run build`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68ba7b8831f4832e90f089d6a5433bf2