### PR TITLE
feat: integrate jwt auth and follow hooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "styled-components": "^5.3.11",
-    "zod": "^4.1.5"
+    "zod": "^4.1.5",
+    "zustand": "^4.5.2"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/src/app/auctions/new/page.tsx
+++ b/src/app/auctions/new/page.tsx
@@ -2,6 +2,7 @@
 import { useCreateAuction, useUploadAuctionImages } from "@/lib/queries/auction";
 import { useRouter } from "next/navigation";
 import { useRef, useState } from "react";
+import Guard from "@/components/auth/Guard";
 
 const ALLOWED = ["image/jpeg","image/png","image/webp","image/gif"];
 const MAX_SIZE = 8 * 1024 * 1024;
@@ -59,6 +60,7 @@ export default function AuctionNewPage() {
   };
 
   return (
+    <Guard>
     <div className="mx-auto max-w-3xl px-4 py-6 grid gap-6">
       <h1 className="text-2xl font-extrabold">Yeni Mezat Oluştur</h1>
 
@@ -127,6 +129,7 @@ export default function AuctionNewPage() {
         </div>
       </form>
     </div>
+    </Guard>
   );
 }
 

--- a/src/app/listings/page.tsx
+++ b/src/app/listings/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useMemo, useState } from "react";
-import { useListingsSearch, type ListingsSearchParams } from "@/lib/queries/listings";
+import { useListings, type ListingsSearchParams } from "@/lib/queries/listings";
 import ListingCard from "@/components/listings/ListingCard";
 import ListingFilters, { type Filters } from "@/components/listings/ListingFilters";
 
@@ -10,7 +10,7 @@ export default function ListingsPage() {
         page: 0, size: 24, sortBy: "createdAt", sortDir: "DESC",
     });
 
-    const { data, isLoading, isError } = useListingsSearch(params);
+    const { data, isLoading, isError } = useListings(params);
     const page = data?.number ?? 0;
     const totalPages = data?.totalPages ?? 0;
 

--- a/src/app/login/LoginForm.tsx
+++ b/src/app/login/LoginForm.tsx
@@ -1,0 +1,55 @@
+"use client";
+import { useState } from "react";
+import Link from "next/link";
+import { useLogin } from "@/lib/auth/hooks";
+
+export default function LoginForm() {
+  const m = useLogin();
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+
+  return (
+    <div className="mx-auto max-w-sm px-4 py-16">
+      <h1 className="text-2xl font-extrabold">Giriş Yap</h1>
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          m.mutate({ email, password });
+        }}
+        className="mt-6 grid gap-3"
+      >
+        <input
+          className="input"
+          placeholder="E-posta"
+          type="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          required
+        />
+        <input
+          className="input"
+          placeholder="Şifre"
+          type="password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          required
+        />
+        <button
+          disabled={m.isPending}
+          className="rounded-lg bg-blue-600 px-4 py-2 text-white"
+        >
+          {m.isPending ? "Giriş yapılıyor…" : "Giriş Yap"}
+        </button>
+      </form>
+      <p className="mt-3 text-sm text-neutral-500">
+        Hesabın yok mu?{" "}
+        <Link href="/register" className="text-sky-400">
+          Kayıt ol
+        </Link>
+      </p>
+      {m.isError && (
+        <p className="mt-2 text-sm text-red-400">Giriş başarısız</p>
+      )}
+    </div>
+  );
+}

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,0 +1,8 @@
+import type { Metadata } from "next";
+import LoginForm from "./LoginForm";
+
+export const metadata: Metadata = { title: "Giriş Yap" };
+
+export default function LoginPage() {
+  return <LoginForm />;
+}

--- a/src/app/me/page.tsx
+++ b/src/app/me/page.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { useMyProfile, useInitMyProfile } from "@/lib/queries/profile";
 import FollowPanel from "@/components/me/FollowPanel";
+import Guard from "@/components/auth/Guard";
 
 import ProfileHeader from "@/components/me/ProfileHeader";
 import ProfileForm from "@/components/me/ProfileForm";
@@ -17,33 +18,37 @@ export default function MePage() {
 
     if (isLoading) {
         return (
-            <div className="mx-auto max-w-6xl px-4 py-10">
-                <div className="text-sm text-neutral-400">Yükleniyor…</div>
-            </div>
+            <Guard>
+                <div className="mx-auto max-w-6xl px-4 py-10">
+                    <div className="text-sm text-neutral-400">Yükleniyor…</div>
+                </div>
+            </Guard>
         );
     }
 
     // Profil yoksa başlat
     if (isError || !data) {
         return (
-            <div className="mx-auto max-w-3xl px-4 py-16 grid gap-4">
-                <h1 className="text-2xl font-bold">Profil bulunamadı</h1>
-                <p className="text-neutral-400">
-                    Henüz bir profiliniz yok gibi görünüyor. Aşağıdaki butona tıklayarak
-                    oluşturabilirsiniz.
-                </p>
-                <button
-                    onClick={() => init.mutate()}
-                    disabled={init.isPending}
-                    className="w-fit rounded-lg bg-blue-600 hover:bg-blue-500 px-4 py-2 text-white disabled:opacity-60"
-                >
-                    {init.isPending ? "Oluşturuluyor…" : "Profilimi Başlat"}
-                </button>
+            <Guard>
+                <div className="mx-auto max-w-3xl px-4 py-16 grid gap-4">
+                    <h1 className="text-2xl font-bold">Profil bulunamadı</h1>
+                    <p className="text-neutral-400">
+                        Henüz bir profiliniz yok gibi görünüyor. Aşağıdaki butona tıklayarak
+                        oluşturabilirsiniz.
+                    </p>
+                    <button
+                        onClick={() => init.mutate()}
+                        disabled={init.isPending}
+                        className="w-fit rounded-lg bg-blue-600 hover:bg-blue-500 px-4 py-2 text-white disabled:opacity-60"
+                    >
+                        {init.isPending ? "Oluşturuluyor…" : "Profilimi Başlat"}
+                    </button>
 
-                <Link href="/" className="text-sm text-neutral-400 hover:text-neutral-200">
-                    ← Anasayfa
-                </Link>
-            </div>
+                    <Link href="/" className="text-sm text-neutral-400 hover:text-neutral-200">
+                        ← Anasayfa
+                    </Link>
+                </div>
+            </Guard>
         );
     }
 
@@ -51,6 +56,7 @@ export default function MePage() {
     const me = data;
 
     return (
+        <Guard>
         <div className="mx-auto max-w-6xl px-4 py-6">
             {/* Breadcrumbs */}
             <nav className="mb-4 text-sm">
@@ -115,5 +121,6 @@ export default function MePage() {
                 </div>
             </div>
         </div>
+        </Guard>
     );
 }

--- a/src/app/register/RegisterForm.tsx
+++ b/src/app/register/RegisterForm.tsx
@@ -1,0 +1,63 @@
+"use client";
+import { useState } from "react";
+import Link from "next/link";
+import { useRegister } from "@/lib/auth/hooks";
+
+export default function RegisterForm() {
+  const m = useRegister();
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [displayName, setDisplayName] = useState("");
+
+  return (
+    <div className="mx-auto max-w-sm px-4 py-16">
+      <h1 className="text-2xl font-extrabold">Kayıt Ol</h1>
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          m.mutate({ email, password, displayName });
+        }}
+        className="mt-6 grid gap-3"
+      >
+        <input
+          className="input"
+          placeholder="Görünen isim"
+          value={displayName}
+          onChange={(e) => setDisplayName(e.target.value)}
+          required
+        />
+        <input
+          className="input"
+          placeholder="E-posta"
+          type="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          required
+        />
+        <input
+          className="input"
+          placeholder="Şifre"
+          type="password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          required
+        />
+        <button
+          disabled={m.isPending}
+          className="rounded-lg bg-blue-600 px-4 py-2 text-white"
+        >
+          {m.isPending ? "Kaydediliyor…" : "Kayıt Ol"}
+        </button>
+      </form>
+      <p className="mt-3 text-sm text-neutral-500">
+        Zaten üye misin?{" "}
+        <Link href="/login" className="text-sky-400">
+          Giriş yap
+        </Link>
+      </p>
+      {m.isError && (
+        <p className="mt-2 text-sm text-red-400">Kayıt başarısız</p>
+      )}
+    </div>
+  );
+}

--- a/src/app/register/page.tsx
+++ b/src/app/register/page.tsx
@@ -1,0 +1,8 @@
+import type { Metadata } from "next";
+import RegisterForm from "./RegisterForm";
+
+export const metadata: Metadata = { title: "Kayıt Ol" };
+
+export default function RegisterPage() {
+  return <RegisterForm />;
+}

--- a/src/app/sell/page.tsx
+++ b/src/app/sell/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useMemo, useState, ChangeEvent, FormEvent } from "react";
 import { useRouter } from "next/navigation";
 import { CheckCircleIcon, ExclamationTriangleIcon } from "@heroicons/react/24/solid";
+import Guard from "@/components/auth/Guard";
 
 const API_BASE = process.env.NEXT_PUBLIC_API_BASE ?? "http://localhost:8080";
 
@@ -267,6 +268,7 @@ export default function SellPage() {
   };
 
   return (
+    <Guard>
     <div className="min-h-screen bg-neutral-50 text-neutral-900 dark:bg-neutral-950 dark:text-neutral-100">
       {/* HERO mini */}
       <section className="border-b border-neutral-200 dark:border-white/10">
@@ -560,6 +562,7 @@ export default function SellPage() {
         )}
       </section>
     </div>
+    </Guard>
   );
 }
 

--- a/src/components/auth/Guard.tsx
+++ b/src/components/auth/Guard.tsx
@@ -1,0 +1,17 @@
+"use client";
+import { useEffect, useState } from "react";
+import { useAuthStore } from "@/lib/auth/store";
+
+export default function Guard({ children }: { children: React.ReactNode }) {
+  const [ready, setReady] = useState(false);
+  useEffect(() => {
+    setReady(true);
+  }, []);
+  const authed = useAuthStore((s) => s.isAuthed());
+  if (!ready) return null;
+  if (!authed) {
+    if (typeof window !== "undefined") window.location.href = "/login";
+    return null;
+  }
+  return <>{children}</>;
+}

--- a/src/components/layout/NavAuth.tsx
+++ b/src/components/layout/NavAuth.tsx
@@ -1,0 +1,39 @@
+"use client";
+import Link from "next/link";
+import { useAuthStore } from "@/lib/auth/store";
+import { useLogout } from "@/lib/auth/hooks";
+
+export default function NavAuth() {
+  const isAuthed = useAuthStore((s) => s.isAuthed());
+  const logout = useLogout();
+
+  if (!isAuthed) {
+    return (
+      <div className="flex items-center gap-3">
+        <Link href="/login" className="text-sm hover:text-sky-400">
+          Giriş
+        </Link>
+        <Link
+          href="/register"
+          className="text-sm rounded-lg bg-sky-600 px-3 py-1.5 text-white"
+        >
+          Kayıt Ol
+        </Link>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex items-center gap-3">
+      <Link href="/me" className="text-sm hover:text-sky-400">
+        Profilim
+      </Link>
+      <button
+        onClick={logout}
+        className="text-sm rounded-lg border border-white/20 px-3 py-1.5"
+      >
+        Çıkış
+      </button>
+    </div>
+  );
+}

--- a/src/components/layout/SiteHeader.tsx
+++ b/src/components/layout/SiteHeader.tsx
@@ -1,8 +1,8 @@
 import Link from "next/link";
 import {
-    UserCircleIcon,
     MagnifyingGlassIcon,
 } from "@heroicons/react/24/outline";
+import NavAuth from "./NavAuth";
 
 export default function SiteHeader() {
     return (
@@ -36,15 +36,7 @@ export default function SiteHeader() {
                             aria-label="Arama"
                         />
                     </div>
-                    <Link
-                        href="/me"
-                        className="inline-flex items-center gap-2 rounded-full px-3 py-1.5 text-sm font-semibold hover:bg-neutral-100 dark:hover:bg-white/10"
-                        title="Profilim"
-                        aria-label="Profilim"
-                    >
-                        <UserCircleIcon className="h-5 w-5" aria-hidden />
-                        <span className="hidden sm:inline">Profilim</span>
-                    </Link>
+                    <NavAuth />
                 </div>
             </div>
         </header>

--- a/src/components/profile/FollowButton.tsx
+++ b/src/components/profile/FollowButton.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { useState, useEffect } from "react";
-import { useFollow, useUnfollow } from "@/lib/queries/profile";
+import { useFollow, useUnfollow } from "@/lib/queries/follow";
 
 export default function FollowButton({
   username,

--- a/src/components/profile/FollowList.tsx
+++ b/src/components/profile/FollowList.tsx
@@ -1,15 +1,16 @@
 "use client";
 
 import Link from "next/link";
-import { useMyProfile, useFollowers, useFollowing } from "@/lib/queries/profile";
+import { useMyProfile } from "@/lib/queries/profile";
+import { useFollowers, useFollowing } from "@/lib/queries/follow";
 
 export function FollowersList({ username }: { username: string }) {
   const { data, isLoading, isError } = useFollowers(username);
   if (isLoading) return <p className="text-sm text-neutral-400">Yükleniyor…</p>;
   if (isError) return <p className="text-sm text-red-400">Takipçiler alınamadı.</p>;
 
-  if (!data?.items?.length) return <p className="text-sm text-neutral-400">Takipçi yok.</p>;
-  return <UserList items={data.items} />;
+  if (!data?.content?.length) return <p className="text-sm text-neutral-400">Takipçi yok.</p>;
+  return <UserList items={data.content} />;
 }
 
 export function FollowingList({ username }: { username: string }) {
@@ -17,8 +18,8 @@ export function FollowingList({ username }: { username: string }) {
   if (isLoading) return <p className="text-sm text-neutral-400">Yükleniyor…</p>;
   if (isError) return <p className="text-sm text-red-400">Takip edilenler alınamadı.</p>;
 
-  if (!data?.items?.length) return <p className="text-sm text-neutral-400">Kimseyi takip etmiyorsun.</p>;
-  return <UserList items={data.items} />;
+  if (!data?.content?.length) return <p className="text-sm text-neutral-400">Kimseyi takip etmiyorsun.</p>;
+  return <UserList items={data.content} />;
 }
 
 function UserList({ items }: { items: {username:string;displayName?:string|null;avatarUrl?:string|null;isVerified?:boolean|null}[] }) {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,6 +1,61 @@
 import axios from "axios";
 
-export const api = axios.create({
-  baseURL: process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8080/api/v1",
-  withCredentials: true,
+export const API_BASE = process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://localhost:8080";
+
+const api = axios.create({
+  baseURL: API_BASE,
+  headers: { "Content-Type": "application/json" },
 });
+
+api.interceptors.request.use((config) => {
+  if (typeof window !== "undefined") {
+    const token = sessionStorage.getItem("accessToken");
+    if (token) config.headers.Authorization = `Bearer ${token}`;
+  }
+  return config;
+});
+
+let refreshing = false;
+let queue: Array<() => void> = [];
+
+api.interceptors.response.use(
+  (res) => res,
+  async (err) => {
+    const original: any = err.config;
+    const status = err?.response?.status;
+
+    if (status === 401 && !original?._retry) {
+      if (refreshing) {
+        await new Promise<void>((ok) => queue.push(ok));
+        return api(original);
+      }
+      refreshing = true;
+      original._retry = true;
+
+      try {
+        const rt = sessionStorage.getItem("refreshToken");
+        if (!rt) throw new Error("No refresh token");
+        const r = await axios.post(`${API_BASE}/api/v1/auth/refresh`, { refreshToken: rt });
+        sessionStorage.setItem("accessToken", r.data.accessToken);
+        if (r.data.refreshToken) sessionStorage.setItem("refreshToken", r.data.refreshToken);
+        refreshing = false;
+        queue.forEach((resume) => resume());
+        queue = [];
+        return api(original);
+      } catch (e) {
+        refreshing = false;
+        queue = [];
+        if (typeof window !== "undefined") {
+          sessionStorage.removeItem("accessToken");
+          sessionStorage.removeItem("refreshToken");
+          location.href = "/login";
+        }
+        throw e;
+      }
+    }
+
+    throw err;
+  }
+);
+
+export default api;

--- a/src/lib/auth/hooks.ts
+++ b/src/lib/auth/hooks.ts
@@ -1,0 +1,34 @@
+import api from "@/lib/api";
+import { useMutation } from "@tanstack/react-query";
+import { useAuthStore } from "./store";
+
+export function useLogin() {
+  const setTokens = useAuthStore((s) => s.setTokens);
+  return useMutation({
+    mutationFn: async (payload: { email: string; password: string }) => {
+      const r = await api.post("/api/v1/auth/login", payload);
+      return r.data as { accessToken: string; refreshToken: string; expiresIn?: number };
+    },
+    onSuccess: (d) => {
+      setTokens(d.accessToken, d.refreshToken);
+      window.location.href = "/";
+    },
+  });
+}
+
+export function useRegister() {
+  return useMutation({
+    mutationFn: async (payload: { email: string; password: string; displayName: string }) => {
+      const r = await api.post("/api/v1/auth/register", payload);
+      return r.data;
+    },
+  });
+}
+
+export function useLogout() {
+  const clear = useAuthStore((s) => s.clear);
+  return () => {
+    clear();
+    window.location.href = "/login";
+  };
+}

--- a/src/lib/auth/store.ts
+++ b/src/lib/auth/store.ts
@@ -1,0 +1,32 @@
+import { create } from "zustand";
+
+type AuthState = {
+  accessToken: string | null;
+  refreshToken: string | null;
+  setTokens: (a: string, r: string | null) => void;
+  clear: () => void;
+  isAuthed: () => boolean;
+};
+
+export const useAuthStore = create<AuthState>((set, get) => ({
+  accessToken: null,
+  refreshToken: null,
+  setTokens: (a, r) => {
+    if (typeof window !== "undefined") {
+      sessionStorage.setItem("accessToken", a);
+      if (r) sessionStorage.setItem("refreshToken", r);
+    }
+    set({ accessToken: a, refreshToken: r ?? get().refreshToken });
+  },
+  clear: () => {
+    if (typeof window !== "undefined") {
+      sessionStorage.removeItem("accessToken");
+      sessionStorage.removeItem("refreshToken");
+    }
+    set({ accessToken: null, refreshToken: null });
+  },
+  isAuthed: () => {
+    if (typeof window === "undefined") return false;
+    return !!sessionStorage.getItem("accessToken");
+  },
+}));

--- a/src/lib/queries/auction.ts
+++ b/src/lib/queries/auction.ts
@@ -1,28 +1,33 @@
 "use client";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { api } from "@/lib/api";
+import api from "@/lib/api";
 import type {
-  AuctionListItemDto, AuctionResponseDto,
-  BidResponseDto, AuctionCreateRequest, BidCreateRequest, UploadResult, AuctionUpdateRequest
+  AuctionListItemDto,
+  AuctionResponseDto,
+  BidResponseDto,
+  AuctionCreateRequest,
+  BidCreateRequest,
+  UploadResult,
+  AuctionUpdateRequest,
 } from "@/lib/types/auction";
 
-export const useAuctions = () =>
+export const useAuctions = (params?: Record<string, unknown>) =>
   useQuery<AuctionListItemDto[]>({
-    queryKey: ["auctions"],
-    queryFn: async () => (await api.get("/auctions")).data,
+    queryKey: ["auctions", params],
+    queryFn: async () => (await api.get("/api/v1/auctions", { params })).data,
   });
 
 export const useAuction = (id: number) =>
   useQuery<AuctionResponseDto>({
     queryKey: ["auction", id],
-    queryFn: async () => (await api.get(`/auctions/${id}`)).data,
+    queryFn: async () => (await api.get(`/api/v1/auctions/${id}`)).data,
     enabled: !!id,
   });
 
 export const useBids = (id: number) =>
   useQuery<BidResponseDto[]>({
     queryKey: ["auction-bids", id],
-    queryFn: async () => (await api.get(`/auctions/${id}/bids`)).data,
+    queryFn: async () => (await api.get(`/api/v1/auctions/${id}/bids`)).data,
     enabled: !!id,
   });
 
@@ -30,8 +35,8 @@ export const useCreateAuction = () => {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: async (body: AuctionCreateRequest) =>
-      (await api.post("/auctions", body)).data as AuctionResponseDto,
-    onSuccess: () => qc.invalidateQueries({ queryKey:["auctions"] }),
+      (await api.post("/api/v1/auctions", body)).data as AuctionResponseDto,
+    onSuccess: () => qc.invalidateQueries({ queryKey: ["auctions"] }),
   });
 };
 
@@ -42,7 +47,7 @@ export const useUploadAuctionImages = () => {
       const fd = new FormData();
       files.forEach((f) => fd.append("files", f));
       return (
-        await api.post(`/auctions/${id}/images`, fd, {
+        await api.post(`/api/v1/auctions/${id}/images`, fd, {
           headers: { "Content-Type": "multipart/form-data" },
         })
       ).data as UploadResult[];
@@ -57,27 +62,17 @@ export const usePlaceBid = (id: number) => {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: async (body: BidCreateRequest) =>
-      (await api.post(`/auctions/${id}/bids`, body)).data as BidResponseDto,
+      (await api.post(`/api/v1/auctions/${id}/bids`, body)).data as BidResponseDto,
     onSuccess: () => {
-      qc.invalidateQueries({ queryKey:["auction", id] });
-      qc.invalidateQueries({ queryKey:["auction-bids", id] });
-    }
+      qc.invalidateQueries({ queryKey: ["auction", id] });
+      qc.invalidateQueries({ queryKey: ["auction-bids", id] });
+    },
   });
 };
 
 async function call<T = unknown>(method: "PUT" | "DELETE", url: string, body?: unknown): Promise<T> {
-  const r = await fetch(url, {
-    method,
-    credentials: "include",
-    headers: body ? { "Content-Type": "application/json" } : undefined,
-    body: body ? JSON.stringify(body) : undefined,
-  });
-  if (!r.ok) throw new Error(await r.text());
-  try {
-    return (await r.json()) as T;
-  } catch {
-    return null as unknown as T;
-  }
+  const r = await api.request<T>({ url, method, data: body });
+  return r.status === 204 ? (null as unknown as T) : r.data;
 }
 
 export const useUpdateAuction = (id: number) => {

--- a/src/lib/queries/follow.ts
+++ b/src/lib/queries/follow.ts
@@ -1,0 +1,40 @@
+import api from "@/lib/api";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+
+export type FollowUser = { username: string; displayName?: string | null; avatarUrl?: string | null; isVerified?: boolean | null; };
+export type FollowPage = { content: FollowUser[]; page: number; size: number; totalElements: number; totalPages: number; last: boolean; };
+
+export function useFollowers(username: string, page=0, size=20) {
+  return useQuery<FollowPage>({
+    queryKey: ["followers", username, page, size],
+    queryFn: async () => (await api.get(`/api/v1/follows/${username}/followers`, { params: { page, size } })).data,
+    enabled: !!username,
+  });
+}
+export function useFollowing(username: string, page=0, size=20) {
+  return useQuery<FollowPage>({
+    queryKey: ["following", username, page, size],
+    queryFn: async () => (await api.get(`/api/v1/follows/${username}/following`, { params: { page, size } })).data,
+    enabled: !!username,
+  });
+}
+export function useFollow(username: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async () => (await api.post(`/api/v1/follows/${username}`)).data,
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["followers", username] });
+      qc.invalidateQueries({ queryKey: ["following"] });
+    },
+  });
+}
+export function useUnfollow(username: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async () => (await api.delete(`/api/v1/follows/${username}`)).data,
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["followers", username] });
+      qc.invalidateQueries({ queryKey: ["following"] });
+    },
+  });
+}

--- a/src/lib/queries/listings.ts
+++ b/src/lib/queries/listings.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { api } from "@/lib/api";
+import api from "@/lib/api";
 import type { ListingResponseDto, Page, ListingUpdateRequest } from "@/lib/types/listing";
 
 // Backend: GET /api/v1/listings/me -> ListingResponseDto[]
@@ -82,11 +82,11 @@ const toQuery = (p: ListingsSearchParams = {}) => {
     return u.toString();
 };
 
-export function useListingsSearch(p: ListingsSearchParams) {
+export function useListings(p: ListingsSearchParams) {
     const qs = toQuery(p);
     return useQuery({
         queryKey: qkListings.search(qs),
-        queryFn: (): Promise<Page<ListingResponseDto>> => getJSON(`/listings?${qs}`),
+        queryFn: (): Promise<Page<ListingResponseDto>> => getJSON(`/api/v1/listings?${qs}`),
         staleTime: 30_000,
     });
 }
@@ -94,7 +94,7 @@ export function useListingsSearch(p: ListingsSearchParams) {
 export function useListingById(id: number) {
     return useQuery({
         queryKey: qkListings.byId(id),
-        queryFn: (): Promise<ListingResponseDto> => getJSON(`/listings/${id}`),
+        queryFn: (): Promise<ListingResponseDto> => getJSON(`/api/v1/listings/${id}`),
         enabled: Number.isFinite(id),
         staleTime: 30_000,
     });
@@ -103,7 +103,7 @@ export function useListingById(id: number) {
 export function usePublicListing(id: number) {
     return useQuery<PublicListingDto>({
         queryKey: ["listing", id],
-        queryFn: () => getJSON(`/listings/${id}`),
+        queryFn: () => getJSON(`/api/v1/listings/${id}`),
         enabled: !!id,
     });
 }
@@ -112,7 +112,7 @@ export function useMyActiveListings() {
     return useQuery({
         queryKey: ["myListings", "active"],
         queryFn: async () => {
-            const data = await getJSON<MyListingMini[]>("/listings/me");
+            const data = await getJSON<MyListingMini[]>("/api/v1/listings/me");
             // endpoint zaten aktifleri döndürüyor; yine de filtre kalsın:
             return (data ?? []).filter((x) => x.status === "ACTIVE" && (x.isActive ?? true));
         },
@@ -134,7 +134,7 @@ async function call<T = unknown>(method: "PUT" | "DELETE", path: string, body?: 
 export function useMyListing(id: number) {
     return useQuery<ListingResponseDto>({
         queryKey: ["myListing", id],
-        queryFn: () => getJSON(`/listings/me/${id}`),
+        queryFn: () => getJSON(`/api/v1/listings/me/${id}`),
         enabled: !!id,
     });
 }
@@ -142,7 +142,7 @@ export function useMyListing(id: number) {
 export function useUpdateListing(id: number) {
     const qc = useQueryClient();
     return useMutation({
-        mutationFn: (req: ListingUpdateRequest) => call("PUT", `/listings/${id}`, req),
+        mutationFn: (req: ListingUpdateRequest) => call("PUT", `/api/v1/listings/${id}`, req),
         onSuccess: () => {
             qc.invalidateQueries({ queryKey: ["myListing", id] });
             qc.invalidateQueries({ queryKey: ["myListings"] });
@@ -154,7 +154,7 @@ export function useUpdateListing(id: number) {
 export function useDeleteListing(id: number) {
     const qc = useQueryClient();
     return useMutation({
-        mutationFn: () => call("DELETE", `/listings/${id}`),
+        mutationFn: () => call("DELETE", `/api/v1/listings/${id}`),
         onSuccess: () => {
             qc.invalidateQueries({ queryKey: ["myListings"] });
             qc.invalidateQueries({ queryKey: ["listings"] });

--- a/src/lib/queries/profile.ts
+++ b/src/lib/queries/profile.ts
@@ -1,13 +1,12 @@
 "use client";
 
-import { api } from "@/lib/api";
+import api from "@/lib/api";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import type {
     ProfileOwnerDto, ProfilePublicDto, ProfileUpdateRequest,
     ProfilePrefsDto, ProfilePrefsUpdateRequest,
     NotificationSettingsDto, NotificationSettingsUpdateRequest,
     ProfileLinkDto, UsernameAvailabilityDto, UsernameSuggestionsDto,
-    FollowListResponse,
 } from "@/lib/types/profile";
 
 // Fetch helpers for public profile and follow APIs
@@ -18,15 +17,6 @@ import type {
 async function getJSON<T>(url: string): Promise<T> {
     const r = await api.get<T>(url);
     return r.data;
-}
-
-async function call(method: "POST" | "DELETE", url: string, body?: unknown) {
-    const r = await api.request({
-        url,
-        method,
-        data: body,
-    });
-    return r.status === 204 ? null : r.data;
 }
 
 export const qk = {
@@ -42,13 +32,13 @@ export const qk = {
 export function useMyProfile() {
     return useQuery<ProfileOwnerDto>({
         queryKey: qk.me,
-        queryFn: async () => (await api.get("/profiles/me")).data,
+        queryFn: async () => (await api.get("/api/v1/profiles/me")).data,
     });
 }
 export function useCheckUsername(u: string) {
     return useQuery<UsernameAvailabilityDto>({
         queryKey: qk.usernameCheck(u),
-        queryFn: async () => (await api.get("/profiles/check-username", { params: { username: u } })).data,
+        queryFn: async () => (await api.get("/api/v1/profiles/check-username", { params: { username: u } })).data,
         enabled: !!u && u.length >= 3,
         staleTime: 30_000,
     });
@@ -56,21 +46,21 @@ export function useCheckUsername(u: string) {
 export function useSuggestUsername(base?: string) {
     return useQuery<UsernameSuggestionsDto>({
         queryKey: qk.usernameSuggest(base),
-        queryFn: async () => (await api.get("/profiles/suggest-username", { params: { base } })).data,
+        queryFn: async () => (await api.get("/api/v1/profiles/suggest-username", { params: { base } })).data,
     });
 }
 
 export function useInitMyProfile() {
     const qc = useQueryClient();
     return useMutation<ProfileOwnerDto, unknown, void>({
-        mutationFn: async () => (await api.post("/profiles/me/init")).data,
+        mutationFn: async () => (await api.post("/api/v1/profiles/me/init")).data,
         onSuccess: () => { qc.invalidateQueries({ queryKey: qk.me }); },
     });
 }
 export function useUpdateMyProfile() {
     const qc = useQueryClient();
     return useMutation<ProfileOwnerDto, unknown, ProfileUpdateRequest>({
-        mutationFn: async (req) => (await api.put("/profiles/me", req)).data,
+        mutationFn: async (req) => (await api.put("/api/v1/profiles/me", req)).data,
         onSuccess: (data) => { qc.setQueryData(qk.me, data); },
     });
 }
@@ -78,7 +68,7 @@ export function useUpdateMyAvatar() {
     const qc = useQueryClient();
     return useMutation<ProfileOwnerDto, unknown, { avatarUrl: string }>({
         mutationFn: async ({ avatarUrl }) =>
-            (await api.put("/profiles/me/avatar", null, { params: { avatarUrl } })).data,
+            (await api.put("/api/v1/profiles/me/avatar", null, { params: { avatarUrl } })).data,
         onSuccess: () => { qc.invalidateQueries({ queryKey: qk.me }); },
     });
 }
@@ -86,14 +76,14 @@ export function useUpdateMyBanner() {
     const qc = useQueryClient();
     return useMutation<ProfileOwnerDto, unknown, { bannerUrl: string }>({
         mutationFn: async ({ bannerUrl }) =>
-            (await api.put("/profiles/me/banner", null, { params: { bannerUrl } })).data,
+            (await api.put("/api/v1/profiles/me/banner", null, { params: { bannerUrl } })).data,
         onSuccess: () => { qc.invalidateQueries({ queryKey: qk.me }); },
     });
 }
 export function useUpdateMyPrefs() {
     const qc = useQueryClient();
     return useMutation<ProfilePrefsDto, unknown, ProfilePrefsUpdateRequest>({
-        mutationFn: async (req) => (await api.put("/profiles/me/prefs", req)).data,
+        mutationFn: async (req) => (await api.put("/api/v1/profiles/me/prefs", req)).data,
         onSuccess: () => {
             qc.invalidateQueries({ queryKey: qk.me });
             qc.invalidateQueries({ queryKey: qk.prefs });
@@ -103,7 +93,7 @@ export function useUpdateMyPrefs() {
 export function useUpdateMyNotifications() {
     const qc = useQueryClient();
     return useMutation<NotificationSettingsDto, unknown, NotificationSettingsUpdateRequest>({
-        mutationFn: async (req) => (await api.put("/profiles/me/notifications", req)).data,
+        mutationFn: async (req) => (await api.put("/api/v1/profiles/me/notifications", req)).data,
         onSuccess: () => {
             qc.invalidateQueries({ queryKey: qk.me });
             qc.invalidateQueries({ queryKey: qk.notif });
@@ -113,7 +103,7 @@ export function useUpdateMyNotifications() {
 export function useUpdateMyLinks() {
     const qc = useQueryClient();
     return useMutation<ProfileLinkDto[], unknown, ProfileLinkDto[]>({
-        mutationFn: async (links) => (await api.put("/profiles/me/links", links)).data,
+        mutationFn: async (links) => (await api.put("/api/v1/profiles/me/links", links)).data,
         onSuccess: () => {
             qc.invalidateQueries({ queryKey: qk.me });
             qc.invalidateQueries({ queryKey: qk.links });
@@ -127,7 +117,7 @@ export function useUploadMyAvatar() {
         mutationFn: async (file) => {
             const fd = new FormData();
             fd.append("file", file);
-            const res = await api.post("/profiles/me/avatar/upload", fd, {
+            const res = await api.post("/api/v1/profiles/me/avatar/upload", fd, {
                 headers: { "Content-Type": "multipart/form-data" },
             });
             return res.data;
@@ -144,7 +134,7 @@ export function useUploadMyBanner() {
         mutationFn: async (file) => {
             const fd = new FormData();
             fd.append("file", file);
-            const res = await api.post("/profiles/me/banner/upload", fd, {
+            const res = await api.post("/api/v1/profiles/me/banner/upload", fd, {
                 headers: { "Content-Type": "multipart/form-data" },
             });
             return res.data;
@@ -155,58 +145,12 @@ export function useUploadMyBanner() {
     });
 }
 
-// ---- FOLLOW / UNFOLLOW ----
-export function useFollow(username: string) {
-    const qc = useQueryClient();
-    return useMutation({
-        mutationFn: () => call("POST", `/profiles/${encodeURIComponent(username)}/follow`),
-        onSuccess: () => {
-            qc.invalidateQueries({ queryKey: ["publicProfile", username] });
-            qc.invalidateQueries({ queryKey: ["followers", username] });
-            qc.invalidateQueries({ queryKey: ["following", username] });
-            qc.invalidateQueries({ queryKey: qk.me });
-        },
-    });
-}
-
-export function useUnfollow(username: string) {
-    const qc = useQueryClient();
-    return useMutation({
-        mutationFn: () => call("DELETE", `/profiles/${encodeURIComponent(username)}/follow`),
-        onSuccess: () => {
-            qc.invalidateQueries({ queryKey: ["publicProfile", username] });
-            qc.invalidateQueries({ queryKey: ["followers", username] });
-            qc.invalidateQueries({ queryKey: ["following", username] });
-            qc.invalidateQueries({ queryKey: qk.me });
-        },
-    });
-}
-
-// ---- LİSTELER ----
-export function useFollowers(username: string, page = 0, size = 20) {
-    const url = `/profiles/${encodeURIComponent(username)}/followers?page=${page}&size=${size}`;
-    return useQuery<FollowListResponse>({
-        queryKey: ["followers", username, page, size],
-        queryFn: () => getJSON(url),
-        enabled: !!username,
-    });
-}
-
-export function useFollowing(username: string, page = 0, size = 20) {
-    const url = `/profiles/${encodeURIComponent(username)}/following?page=${page}&size=${size}`;
-    return useQuery<FollowListResponse>({
-        queryKey: ["following", username, page, size],
-        queryFn: () => getJSON(url),
-        enabled: !!username,
-    });
-}
-
 // ---- PUBLIC PROFİL (viewer destekli) ----
 export function usePublicProfile(username: string, viewerUserId?: number) {
     const q = new URLSearchParams();
     if (viewerUserId != null) q.set("viewerUserId", String(viewerUserId));
     const qs = q.toString();
-    const url = `/profiles/${encodeURIComponent(username)}${qs ? `?${qs}` : ""}`;
+    const url = `/api/v1/profiles/${encodeURIComponent(username)}${qs ? `?${qs}` : ""}`;
     return useQuery<ProfilePublicDto>({
         queryKey: ["publicProfile", username, viewerUserId ?? null],
         queryFn: () => getJSON(url),


### PR DESCRIPTION
## Summary
- add axios client with JWT refresh handling
- build auth store/hooks and login/register pages
- wire follow, listings, and auctions queries through axios and guard protected routes

## Testing
- `npm run build` *(fails: Module not found: Can't resolve 'zustand')*


------
https://chatgpt.com/codex/tasks/task_e_68bb27c10794832e82e4965789a19c10