### PR TITLE
Fix login and registration payloads

### DIFF
--- a/src/app/login/LoginForm.tsx
+++ b/src/app/login/LoginForm.tsx
@@ -5,7 +5,7 @@ import { useLogin } from "@/lib/auth/hooks";
 
 export default function LoginForm() {
   const m = useLogin();
-  const [email, setEmail] = useState("");
+  const [emailOrUsername, setEmailOrUsername] = useState("");
   const [password, setPassword] = useState("");
 
   return (
@@ -14,16 +14,16 @@ export default function LoginForm() {
       <form
         onSubmit={(e) => {
           e.preventDefault();
-          m.mutate({ email, password });
+          m.mutate({ emailOrUsername, password });
         }}
         className="mt-6 grid gap-3"
       >
         <input
           className="input"
-          placeholder="E-posta"
-          type="email"
-          value={email}
-          onChange={(e) => setEmail(e.target.value)}
+          placeholder="E-posta veya kullanıcı adı"
+          type="text"
+          value={emailOrUsername}
+          onChange={(e) => setEmailOrUsername(e.target.value)}
           required
         />
         <input

--- a/src/app/register/RegisterForm.tsx
+++ b/src/app/register/RegisterForm.tsx
@@ -7,7 +7,7 @@ export default function RegisterForm() {
   const m = useRegister();
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
-  const [displayName, setDisplayName] = useState("");
+  const [username, setUsername] = useState("");
 
   return (
     <div className="mx-auto max-w-sm px-4 py-16">
@@ -15,15 +15,15 @@ export default function RegisterForm() {
       <form
         onSubmit={(e) => {
           e.preventDefault();
-          m.mutate({ email, password, displayName });
+          m.mutate({ email, password, username });
         }}
         className="mt-6 grid gap-3"
       >
         <input
           className="input"
-          placeholder="Görünen isim"
-          value={displayName}
-          onChange={(e) => setDisplayName(e.target.value)}
+          placeholder="Kullanıcı adı"
+          value={username}
+          onChange={(e) => setUsername(e.target.value)}
           required
         />
         <input

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,4 +1,4 @@
-import axios from "axios";
+import axios, { AxiosError, AxiosRequestConfig } from "axios";
 
 export const API_BASE = process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://localhost:8080";
 
@@ -20,9 +20,9 @@ let queue: Array<() => void> = [];
 
 api.interceptors.response.use(
   (res) => res,
-  async (err) => {
-    const original: any = err.config;
-    const status = err?.response?.status;
+  async (err: AxiosError) => {
+      const original = err.config as AxiosRequestConfig & { _retry?: boolean };
+      const status = err?.response?.status;
 
     if (status === 401 && !original?._retry) {
       if (refreshing) {

--- a/src/lib/auth/hooks.ts
+++ b/src/lib/auth/hooks.ts
@@ -5,7 +5,7 @@ import { useAuthStore } from "./store";
 export function useLogin() {
   const setTokens = useAuthStore((s) => s.setTokens);
   return useMutation({
-    mutationFn: async (payload: { email: string; password: string }) => {
+    mutationFn: async (payload: { emailOrUsername: string; password: string }) => {
       const r = await api.post("/api/v1/auth/login", payload);
       return r.data as { accessToken: string; refreshToken: string; expiresIn?: number };
     },
@@ -18,7 +18,7 @@ export function useLogin() {
 
 export function useRegister() {
   return useMutation({
-    mutationFn: async (payload: { email: string; password: string; displayName: string }) => {
+    mutationFn: async (payload: { email: string; password: string; username: string }) => {
       const r = await api.post("/api/v1/auth/register", payload);
       return r.data;
     },


### PR DESCRIPTION
## Summary
- send `emailOrUsername` and `username` in auth hooks
- allow username or email in login form and add username field in registration
- improve Axios interceptor typing

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bb381b3b18832eb42c2c88adc4eee9