### PR TITLE
Use JWT user id for profile API calls

### DIFF
--- a/src/lib/auth/store.ts
+++ b/src/lib/auth/store.ts
@@ -3,27 +3,41 @@ import { create } from "zustand";
 type AuthState = {
   accessToken: string | null;
   refreshToken: string | null;
+  userId: number | null;
   setTokens: (a: string, r: string | null) => void;
   clear: () => void;
   isAuthed: () => boolean;
 };
 
 export const useAuthStore = create<AuthState>((set, get) => ({
-  accessToken: null,
-  refreshToken: null,
+  accessToken: typeof window !== "undefined" ? sessionStorage.getItem("accessToken") : null,
+  refreshToken: typeof window !== "undefined" ? sessionStorage.getItem("refreshToken") : null,
+  userId: typeof window !== "undefined" ? Number(sessionStorage.getItem("userId")) || null : null,
   setTokens: (a, r) => {
+    let uid: number | null = null;
+    try {
+      const payload = JSON.parse(atob(a.split(".")[1] || ""));
+      uid = payload?.userId ?? payload?.sub ?? null;
+      if (typeof uid === "string") uid = Number(uid);
+    } catch {
+      uid = null;
+    }
+
     if (typeof window !== "undefined") {
       sessionStorage.setItem("accessToken", a);
       if (r) sessionStorage.setItem("refreshToken", r);
+      if (uid != null) sessionStorage.setItem("userId", String(uid));
     }
-    set({ accessToken: a, refreshToken: r ?? get().refreshToken });
+
+    set({ accessToken: a, refreshToken: r ?? get().refreshToken, userId: uid });
   },
   clear: () => {
     if (typeof window !== "undefined") {
       sessionStorage.removeItem("accessToken");
       sessionStorage.removeItem("refreshToken");
+      sessionStorage.removeItem("userId");
     }
-    set({ accessToken: null, refreshToken: null });
+    set({ accessToken: null, refreshToken: null, userId: null });
   },
   isAuthed: () => {
     if (typeof window === "undefined") return false;

--- a/src/lib/queries/profile.ts
+++ b/src/lib/queries/profile.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import api from "@/lib/api";
+import { useAuthStore } from "@/lib/auth/store";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import type {
     ProfileOwnerDto, ProfilePublicDto, ProfileUpdateRequest,
@@ -30,9 +31,11 @@ export const qk = {
 };
 
 export function useMyProfile() {
+    const userId = useAuthStore((s) => s.userId);
     return useQuery<ProfileOwnerDto>({
         queryKey: qk.me,
-        queryFn: async () => (await api.get("/api/v1/profiles/me")).data,
+        queryFn: async () => (await api.get("/api/v1/profiles", { params: { userId } })).data,
+        enabled: userId != null,
     });
 }
 export function useCheckUsername(u: string) {


### PR DESCRIPTION
## Summary
- decode user id from access token and persist in auth store
- query my profile using explicit `userId` parameter

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/zustand)*

------
https://chatgpt.com/codex/tasks/task_e_68bbde663c34832eb85bbe7f8168f9f0