### PR TITLE
Align profile API calls with token auth

### DIFF
--- a/src/app/me/page.tsx
+++ b/src/app/me/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { useMyProfile, useInitMyProfile } from "@/lib/queries/profile";
+import { useMyProfile } from "@/lib/queries/profile";
 import FollowPanel from "@/components/me/FollowPanel";
 import Guard from "@/components/auth/Guard";
 
@@ -14,7 +14,6 @@ import MyListingsGrid from "@/components/me/MyListingsGrid";
 
 export default function MePage() {
     const { data, isLoading, isError } = useMyProfile();
-    const init = useInitMyProfile();
 
     if (isLoading) {
         return (
@@ -26,24 +25,11 @@ export default function MePage() {
         );
     }
 
-    // Profil yoksa başlat
     if (isError || !data) {
         return (
             <Guard>
                 <div className="mx-auto max-w-3xl px-4 py-16 grid gap-4">
-                    <h1 className="text-2xl font-bold">Profil bulunamadı</h1>
-                    <p className="text-neutral-400">
-                        Henüz bir profiliniz yok gibi görünüyor. Aşağıdaki butona tıklayarak
-                        oluşturabilirsiniz.
-                    </p>
-                    <button
-                        onClick={() => init.mutate()}
-                        disabled={init.isPending}
-                        className="w-fit rounded-lg bg-blue-600 hover:bg-blue-500 px-4 py-2 text-white disabled:opacity-60"
-                    >
-                        {init.isPending ? "Oluşturuluyor…" : "Profilimi Başlat"}
-                    </button>
-
+                    <h1 className="text-2xl font-bold">Profil yüklenemedi</h1>
                     <Link href="/" className="text-sm text-neutral-400 hover:text-neutral-200">
                         ← Anasayfa
                     </Link>

--- a/src/app/sell/page.tsx
+++ b/src/app/sell/page.tsx
@@ -248,9 +248,13 @@ export default function SellPage() {
 
     try {
       setSubmitting(true);
+      const token = typeof window !== "undefined" ? sessionStorage.getItem("accessToken") : null;
       const res = await fetch(`${API_BASE}/api/v1/cars/listings`, {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers: {
+          "Content-Type": "application/json",
+          ...(token ? { Authorization: `Bearer ${token}` } : {}),
+        },
         body: JSON.stringify(payload),
       });
       if (!res.ok) {

--- a/src/app/u/[username]/page.tsx
+++ b/src/app/u/[username]/page.tsx
@@ -13,7 +13,7 @@ import { usePublicProfile } from "@/lib/queries/profile";
 export default function PublicProfilePage() {
   const { username } = useParams<{ username: string }>();
   const me = useMyProfile?.().data; // me hook'unuz nasıl export ediliyorsa öyle kullanın
-  const { data: p, isLoading, isError } = usePublicProfile(username, me?.userId);
+  const { data: p, isLoading, isError } = usePublicProfile(username);
 
   const [open, setOpen] = React.useState<null | "followers" | "following">(null);
 

--- a/src/lib/auth/store.ts
+++ b/src/lib/auth/store.ts
@@ -13,15 +13,15 @@ export const useAuthStore = create<AuthState>((set, get) => ({
   accessToken: typeof window !== "undefined" ? sessionStorage.getItem("accessToken") : null,
   refreshToken: typeof window !== "undefined" ? sessionStorage.getItem("refreshToken") : null,
   userId: typeof window !== "undefined" ? Number(sessionStorage.getItem("userId")) || null : null,
-  setTokens: (a, r) => {
-    let uid: number | null = null;
-    try {
-      const payload = JSON.parse(atob(a.split(".")[1] || ""));
-      uid = payload?.userId ?? payload?.sub ?? null;
-      if (typeof uid === "string") uid = Number(uid);
-    } catch {
-      uid = null;
-    }
+    setTokens: (a, r) => {
+      let uid: number | null = null;
+      try {
+        const payload = JSON.parse(atob(a.split(".")[1] || ""));
+        uid = payload?.uid ?? payload?.userId ?? null;
+        if (typeof uid === "string") uid = Number(uid);
+      } catch {
+        uid = null;
+      }
 
     if (typeof window !== "undefined") {
       sessionStorage.setItem("accessToken", a);


### PR DESCRIPTION
## Summary
- fetch profile data using `/api/v1/profiles/me` without userId
- parse `uid` from token and attach Authorization for listing creation
- remove deprecated profile initialization flow

## Testing
- `npm test` *(fails: Missing script 'test')*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*


------
https://chatgpt.com/codex/tasks/task_e_68bc0a7b18b8832e90a35988e90f84bc