### PR TITLE
Restrict auctions to registered users

### DIFF
--- a/src/app/auctions/page.tsx
+++ b/src/app/auctions/page.tsx
@@ -2,9 +2,23 @@
 import Link from "next/link";
 import { useAuctions } from "@/lib/queries/auction";
 import AuctionCard from "@/components/auction/AuctionCard";
+import { useAuthStore } from "@/lib/auth/store";
+import SignupPromptModal from "@/components/auth/SignupPromptModal";
 
 export default function AuctionsPage() {
+  const isAuthed = useAuthStore((s) => s.isAuthed());
   const { data, isLoading, isError } = useAuctions();
+
+  if (!isAuthed) {
+    return (
+      <SignupPromptModal
+        open={true}
+        onClose={() => {
+          if (typeof window !== "undefined") window.location.href = "/";
+        }}
+      />
+    );
+  }
 
   return (
     <div className="mx-auto max-w-6xl px-4 py-6 grid gap-6">
@@ -20,7 +34,7 @@ export default function AuctionsPage() {
         <div className="min-w-0">
           <h1 className="text-2xl font-extrabold">Mezatlar</h1>
           <p className="text-sm text-neutral-400">
-            Buradan açık artırmalara katıl, koleksiyonunu büyütürken rekabetin keyfini yaşa. 
+            Buradan açık artırmalara katıl, koleksiyonunu büyütürken rekabetin keyfini yaşa.
             Minimum teklif artışı <b>10 TL</b>’dir; son teklifi en az 10 TL geçmen gerekir.
           </p>
         </div>

--- a/src/components/auth/SignupPromptModal.tsx
+++ b/src/components/auth/SignupPromptModal.tsx
@@ -1,0 +1,24 @@
+"use client";
+import Link from "next/link";
+import Modal from "@/components/ui/Modal";
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+}
+
+export default function SignupPromptModal({ open, onClose }: Props) {
+  return (
+    <Modal open={open} onCloseAction={onClose} title="Üye Ol">
+      <p className="mb-4 text-sm text-neutral-300">
+        Mezatlara katılmak için üye olmalısın. Hemen üye olup fırsatları kaçırma!
+      </p>
+      <Link
+        href="/register"
+        className="inline-flex rounded-lg bg-sky-600 px-4 py-2 text-sm font-semibold text-white hover:opacity-95"
+      >
+        Kayıt Ol
+      </Link>
+    </Modal>
+  );
+}

--- a/src/components/layout/SiteHeader.tsx
+++ b/src/components/layout/SiteHeader.tsx
@@ -1,44 +1,61 @@
+"use client";
 import Link from "next/link";
+import { useState } from "react";
 import {
     MagnifyingGlassIcon,
 } from "@heroicons/react/24/outline";
+import { useAuthStore } from "@/lib/auth/store";
+import SignupPromptModal from "@/components/auth/SignupPromptModal";
 import NavAuth from "./NavAuth";
 
 export default function SiteHeader() {
+    const isAuthed = useAuthStore((s) => s.isAuthed());
+    const [showModal, setShowModal] = useState(false);
+
+    const handleAuctionsClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
+        if (!isAuthed) {
+            e.preventDefault();
+            setShowModal(true);
+        }
+    };
+
     return (
-        <header className="sticky top-0 z-50 backdrop-blur bg-white/70 dark:bg-neutral-950/60 border-b border-neutral-200 dark:border-white/10">
-            <div className="mx-auto max-w-6xl px-4 py-3 flex items-center justify-between gap-4">
-                {/* Marka */}
-                <Link href="/" className="flex items-center gap-2" aria-label="Anasayfa">
-                    <div className="h-7 w-7 rounded-lg bg-gradient-to-br from-sky-400 to-blue-600 shadow-sm ring-1 ring-white/40 dark:ring-white/10" />
-                    <span className="font-extrabold tracking-tight text-xl">GarageMint</span>
-                </Link>
+        <>
+            <header className="sticky top-0 z-50 backdrop-blur bg-white/70 dark:bg-neutral-950/60 border-b border-neutral-200 dark:border-white/10">
+                <div className="mx-auto max-w-6xl px-4 py-3 flex items-center justify-between gap-4">
+                    {/* Marka */}
+                    <Link href="/" className="flex items-center gap-2" aria-label="Anasayfa">
+                        <div className="h-7 w-7 rounded-lg bg-gradient-to-br from-sky-400 to-blue-600 shadow-sm ring-1 ring-white/40 dark:ring-white/10" />
+                        <span className="font-extrabold tracking-tight text-xl">GarageMint</span>
+                    </Link>
 
-                {/* Orta menü */}
-                <nav className="hidden md:flex items-center gap-6 text-sm font-semibold text-neutral-600 dark:text-neutral-300">
-                    <Link className="hover:text-neutral-900 dark:hover:text-white" href="/listings">Keşfet</Link>
-                    <Link className="hover:text-neutral-900 dark:hover:text-white" href="/collections">Koleksiyonlar</Link>
-                    <Link className="hover:text-neutral-900 dark:hover:text-white" href="/sell">Satış</Link>
-                    <Link className="hover:text-neutral-900 dark:hover:text-white" href="/auctions">Mezat</Link>
-                    <Link className="hover:text-neutral-900 dark:hover:text-white" href="/about">Hakkımızda</Link>
-                </nav>
+                    {/* Orta menü */}
+                    <nav className="hidden md:flex items-center gap-6 text-sm font-semibold text-neutral-600 dark:text-neutral-300">
+                        <Link className="hover:text-neutral-900 dark:hover:text-white" href="/listings">Keşfet</Link>
+                        <Link className="hover:text-neutral-900 dark:hover:text-white" href="/collections">Koleksiyonlar</Link>
+                        <Link className="hover:text-neutral-900 dark:hover:text-white" href="/sell">Satış</Link>
+                        <Link className="hover:text-neutral-900 dark:hover:text-white" href="/auctions" onClick={handleAuctionsClick}>Mezat</Link>
+                        <Link className="hover:text-neutral-900 dark:hover:text-white" href="/about">Hakkımızda</Link>
+                    </nav>
 
-                {/* Sağ aksiyonlar */}
-                <div className="flex items-center gap-3">
-                    <div
-                        role="search"
-                        className="hidden sm:flex items-center gap-2 rounded-full border border-neutral-200 dark:border-white/10 px-3 py-1.5 bg-white/60 dark:bg-white/5"
-                    >
-                        <MagnifyingGlassIcon className="h-4 w-4 text-neutral-500 dark:text-neutral-400" aria-hidden />
-                        <input
-                            placeholder="Modeller, markalar ara…"
-                            className="bg-transparent outline-none text-sm w-48 placeholder:text-neutral-400"
-                            aria-label="Arama"
-                        />
+                    {/* Sağ aksiyonlar */}
+                    <div className="flex items-center gap-3">
+                        <div
+                            role="search"
+                            className="hidden sm:flex items-center gap-2 rounded-full border border-neutral-200 dark:border-white/10 px-3 py-1.5 bg-white/60 dark:bg-white/5"
+                        >
+                            <MagnifyingGlassIcon className="h-4 w-4 text-neutral-500 dark:text-neutral-400" aria-hidden />
+                            <input
+                                placeholder="Modeller, markalar ara…"
+                                className="bg-transparent outline-none text-sm w-48 placeholder:text-neutral-400"
+                                aria-label="Arama"
+                            />
+                        </div>
+                        <NavAuth />
                     </div>
-                    <NavAuth />
                 </div>
-            </div>
-        </header>
+            </header>
+            <SignupPromptModal open={showModal} onClose={() => setShowModal(false)} />
+        </>
     );
 }


### PR DESCRIPTION
## Summary
- block anonymous users from opening auctions
- show a sign-up modal instead of navigating for unauthenticated visitors

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_68bc194a46ec832ea2bab57b2fbde63e