### PR TITLE
feat: add auth headers to protected fetch calls

### DIFF
--- a/src/app/collections/[slug]/ClientView.tsx
+++ b/src/app/collections/[slug]/ClientView.tsx
@@ -60,6 +60,10 @@ export default function ClientView({ slug, pageIdx }: { slug: string; pageIdx: n
         setLoading(true);
         setErr(null);
 
+        const token =
+          typeof window !== "undefined" ? sessionStorage.getItem("accessToken") : null;
+        const headers = token ? { Authorization: `Bearer ${token}` } : {};
+
         const theme = THEME_BY_SLUG[slug];
 
         // 1) THEME ile ara (varsa)
@@ -72,7 +76,7 @@ export default function ClientView({ slug, pageIdx }: { slug: string; pageIdx: n
           url.searchParams.set("sortBy", "createdAt");
           url.searchParams.set("sortDir", "DESC");
 
-          const res = await fetch(url.toString(), { cache: "no-store" });
+          const res = await fetch(url.toString(), { cache: "no-store", headers });
           if (!res.ok) throw new Error(`HTTP ${res.status}`);
           const json: PageResponse = await res.json();
           if (!canceled) setData(json);
@@ -80,7 +84,10 @@ export default function ClientView({ slug, pageIdx }: { slug: string; pageIdx: n
         }
 
         // 2) Tag slug çöz (yoksa): /tags -> /listings?tagIds=...
-        const tagsRes = await fetch(`${API_BASE}/api/v1/cars/tags`, { cache: "no-store" });
+        const tagsRes = await fetch(`${API_BASE}/api/v1/cars/tags`, {
+          cache: "no-store",
+          headers,
+        });
         if (!tagsRes.ok) throw new Error(`Tags HTTP ${tagsRes.status}`);
         const tags: { id: number; name: string; slug: string }[] = await tagsRes.json();
         const tag = tags.find((t) => t.slug.toLowerCase() === slug.toLowerCase());
@@ -94,7 +101,7 @@ export default function ClientView({ slug, pageIdx }: { slug: string; pageIdx: n
         url.searchParams.set("sortBy", "createdAt");
         url.searchParams.set("sortDir", "DESC");
 
-        const res2 = await fetch(url.toString(), { cache: "no-store" });
+        const res2 = await fetch(url.toString(), { cache: "no-store", headers });
         if (!res2.ok) throw new Error(`HTTP ${res2.status}`);
         const json2: PageResponse = await res2.json();
         if (!canceled) setData(json2);

--- a/src/app/sell/page.tsx
+++ b/src/app/sell/page.tsx
@@ -93,9 +93,13 @@ export default function SellPage() {
         setLoadingInit(true);
         setErrorInit(null);
 
+        const token =
+          typeof window !== "undefined" ? sessionStorage.getItem("accessToken") : null;
+        const headers = token ? { Authorization: `Bearer ${token}` } : {};
+
         const [bRes, tRes] = await Promise.all([
-          fetch(`${API_BASE}/api/v1/cars/brands`, { cache: "no-store" }),
-          fetch(`${API_BASE}/api/v1/cars/tags`, { cache: "no-store" }),
+          fetch(`${API_BASE}/api/v1/cars/brands`, { cache: "no-store", headers }),
+          fetch(`${API_BASE}/api/v1/cars/tags`, { cache: "no-store", headers }),
         ]);
         if (!bRes.ok) throw new Error(`Brands HTTP ${bRes.status}`);
         if (!tRes.ok) throw new Error(`Tags HTTP ${tRes.status}`);
@@ -128,7 +132,14 @@ export default function SellPage() {
     }
     async function loadSeries() {
       try {
-        const res = await fetch(`${API_BASE}/api/v1/cars/series?brandId=${brandId}`, { cache: "no-store" });
+        const token =
+          typeof window !== "undefined" ? sessionStorage.getItem("accessToken") : null;
+        const headers = token ? { Authorization: `Bearer ${token}` } : undefined;
+
+        const res = await fetch(
+          `${API_BASE}/api/v1/cars/series?brandId=${brandId}`,
+          { cache: "no-store", headers },
+        );
         if (!res.ok) throw new Error(`Series HTTP ${res.status}`);
         const json: Series[] = await res.json();
         if (!cancel) {
@@ -138,8 +149,8 @@ export default function SellPage() {
             setForm((prev) => ({ ...prev, seriesId: undefined }));
           }
         }
-        } catch {
-          if (!cancel) setSeries([]);
+      } catch {
+        if (!cancel) setSeries([]);
       }
     }
     loadSeries();


### PR DESCRIPTION
## Summary
- include session token in Sell page requests for brands, tags, and series
- attach auth headers when loading collection listings and tags

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: Cannot find package '@eslint/eslintrc')

------
https://chatgpt.com/codex/tasks/task_e_68bc2e0b5df8832e94d28140f404fffd