### PR TITLE
feat: add error and not-found pages

### DIFF
--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import { useEffect } from "react";
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error;
+  reset: () => void;
+}) {
+  useEffect(() => {
+    // Hata kayıt/logging
+    console.error(error);
+  }, [error]);
+
+  return (
+    <div className="mx-auto flex min-h-[50vh] max-w-xl flex-col items-center justify-center text-center">
+      <h2 className="text-2xl font-bold">Beklenmeyen bir hata oluştu</h2>
+      <p className="mt-2 text-sm text-neutral-500">
+        Lütfen daha sonra tekrar deneyin.
+      </p>
+      <button
+        onClick={reset}
+        className="mt-4 rounded-md bg-sky-600 px-4 py-2 text-white"
+      >
+        Yeniden dene
+      </button>
+    </div>
+  );
+}

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import { useEffect } from "react";
+
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error;
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <html lang="tr">
+      <body className="flex min-h-screen items-center justify-center bg-neutral-950 text-neutral-100">
+        <div className="mx-auto max-w-xl text-center">
+          <h2 className="text-2xl font-bold">Bir şeyler ters gitti</h2>
+          <p className="mt-2 text-sm text-neutral-400">
+            Uygulama beklenmeyen bir hata ile karşılaştı. Lütfen daha sonra tekrar deneyin.
+          </p>
+          <button
+            onClick={reset}
+            className="mt-4 rounded-md bg-sky-600 px-4 py-2 text-white"
+          >
+            Yeniden dene
+          </button>
+        </div>
+      </body>
+    </html>
+  );
+}

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,18 @@
+import Link from "next/link";
+
+export default function NotFound() {
+  return (
+    <div className="mx-auto flex min-h-[50vh] max-w-xl flex-col items-center justify-center text-center">
+      <h2 className="text-2xl font-bold">Sayfa bulunamadı</h2>
+      <p className="mt-2 text-sm text-neutral-500">
+        Aradığınız sayfa mevcut değil veya taşınmış olabilir.
+      </p>
+      <Link
+        href="/"
+        className="mt-4 rounded-md bg-sky-600 px-4 py-2 text-white"
+      >
+        Ana sayfaya dön
+      </Link>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- log and display general message on error via `error.tsx`
- show a 404 template with redirect link
- catch uncaught errors with a root-level global error page

## Testing
- `npm install` *(fails: 403 Forbidden to fetch packages)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68bc3c47ddbc832e9113969eeca2c5ad