### PR TITLE
feat: surface query errors via toast

### DIFF
--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -1,24 +1,38 @@
 "use client";
 import { ThemeProvider } from "@primer/react";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  QueryClient,
+  QueryClientProvider,
+  QueryCache,
+  MutationCache,
+} from "@tanstack/react-query";
 import React from "react";
 import { ToastProvider } from "@/components/ui/toast";
+import { useQueryErrorHandler } from "@/hooks/useQueryErrorHandler";
+
+function QueryProvider({ children }: { children: React.ReactNode }) {
+  const onError = useQueryErrorHandler();
+  const [client] = React.useState(
+    () =>
+      new QueryClient({
+        queryCache: new QueryCache({ onError }),
+        mutationCache: new MutationCache({ onError }),
+        defaultOptions: {
+          queries: { refetchOnWindowFocus: false, retry: 1 },
+          mutations: { retry: 0 },
+        },
+      })
+  );
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
 
 export default function Providers({ children }: { children: React.ReactNode }) {
-    const [client] = React.useState(
-        () =>
-            new QueryClient({
-                defaultOptions: {
-                    queries: { refetchOnWindowFocus: false, retry: 1 },
-                    mutations: { retry: 0 },
-                },
-            })
-    );
-    return (
-        <ThemeProvider colorMode="auto">
-            <QueryClientProvider client={client}>
-                <ToastProvider>{children}</ToastProvider>
-            </QueryClientProvider>
-        </ThemeProvider>
-    );
+  return (
+    <ThemeProvider colorMode="auto">
+      <ToastProvider>
+        <QueryProvider>{children}</QueryProvider>
+      </ToastProvider>
+    </ThemeProvider>
+  );
 }
+

--- a/src/hooks/useQueryErrorHandler.ts
+++ b/src/hooks/useQueryErrorHandler.ts
@@ -1,0 +1,15 @@
+import { useCallback } from "react";
+import { useToast } from "@/components/ui/toast";
+import { getErrorMessage } from "@/lib/api";
+
+export function useQueryErrorHandler() {
+  const { push } = useToast();
+
+  return useCallback(
+    (err: unknown) => {
+      push({ type: "error", title: getErrorMessage(err) });
+    },
+    [push]
+  );
+}
+

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -58,4 +58,15 @@ api.interceptors.response.use(
   }
 );
 
+export function getErrorMessage(err: unknown): string {
+  if (axios.isAxiosError(err)) {
+    const data = err.response?.data as any;
+    if (typeof data === "string") return data;
+    if (data && typeof data.message === "string") return data.message;
+    return err.message;
+  }
+  if (err instanceof Error) return err.message;
+  return typeof err === "string" ? err : "Bilinmeyen hata";
+}
+
 export default api;


### PR DESCRIPTION
## Summary
- add helper to parse Axios errors into readable messages
- show toast notifications for React Query errors

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_68bc3c48f234832e9a325e529659e839