### PR TITLE
Improve auth form error handling

### DIFF
--- a/src/app/register/RegisterForm.tsx
+++ b/src/app/register/RegisterForm.tsx
@@ -1,6 +1,8 @@
 "use client";
 import { useState } from "react";
 import Link from "next/link";
+import { AxiosError } from "axios";
+import { z } from "zod";
 import { useRegister } from "@/lib/auth/hooks";
 
 export default function RegisterForm() {
@@ -8,17 +10,33 @@ export default function RegisterForm() {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [username, setUsername] = useState("");
+  const [formError, setFormError] = useState<string | null>(null);
+
+  const schema = z.object({
+    username: z.string().min(1, "Kullanıcı adı gerekli"),
+    email: z.string().email("Geçersiz e-posta"),
+    password: z.string().min(1, "Şifre gerekli"),
+  });
+
+  const submit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const r = schema.safeParse({ email, password, username });
+    if (!r.success) {
+      setFormError(r.error.issues[0]?.message ?? "Geçersiz kayıt");
+      return;
+    }
+    setFormError(null);
+    m.mutate(r.data);
+  };
+
+  const backendMessage =
+    (m.error as AxiosError<{ message?: string }> | undefined)?.response?.data
+      ?.message || (m.error as any)?.message;
 
   return (
     <div className="mx-auto max-w-sm px-4 py-16">
       <h1 className="text-2xl font-extrabold">Kayıt Ol</h1>
-      <form
-        onSubmit={(e) => {
-          e.preventDefault();
-          m.mutate({ email, password, username });
-        }}
-        className="mt-6 grid gap-3"
-      >
+      <form onSubmit={submit} className="mt-6 grid gap-3">
         <input
           className="input"
           placeholder="Kullanıcı adı"
@@ -55,8 +73,14 @@ export default function RegisterForm() {
           Giriş yap
         </Link>
       </p>
+      {formError && (
+        <p className="mt-2 text-sm text-red-400">{formError}</p>
+      )}
       {m.isError && (
-        <p className="mt-2 text-sm text-red-400">Kayıt başarısız</p>
+        <p className="mt-2 text-sm text-red-400">
+          Kayıt başarısız
+          {backendMessage ? `: ${backendMessage}` : ""}
+        </p>
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
- surface backend-provided error messages in login and registration
- add simple zod validation for login and registration fields
- show default Turkish fallback when backend does not return a message

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_68bc3c4c62d8832e906b3a651f54cfb3