### PR TITLE
fix: correct follower endpoint paths

### DIFF
--- a/src/lib/queries/follow.ts
+++ b/src/lib/queries/follow.ts
@@ -7,14 +7,14 @@ export type FollowPage = { content: FollowUser[]; page: number; size: number; to
 export function useFollowers(username: string, page=0, size=20) {
   return useQuery<FollowPage>({
     queryKey: ["followers", username, page, size],
-    queryFn: async () => (await api.get(`/api/v1/follows/${username}/followers`, { params: { page, size } })).data,
+    queryFn: async () => (await api.get(`/api/v1/profiles/${username}/followers`, { params: { page, size } })).data,
     enabled: !!username,
   });
 }
 export function useFollowing(username: string, page=0, size=20) {
   return useQuery<FollowPage>({
     queryKey: ["following", username, page, size],
-    queryFn: async () => (await api.get(`/api/v1/follows/${username}/following`, { params: { page, size } })).data,
+    queryFn: async () => (await api.get(`/api/v1/profiles/${username}/following`, { params: { page, size } })).data,
     enabled: !!username,
   });
 }


### PR DESCRIPTION
## Summary
- fix follower and following fetch queries to use /api/v1/profiles endpoints

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden)*
- `npm run lint` *(fails: missing @eslint/eslintrc)*

------
https://chatgpt.com/codex/tasks/task_e_68bc766065d0832eb7266fa470de1ed7