### PR TITLE
feat: add global toast error handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "test": "vitest"
   },
   "dependencies": {
     "@heroicons/react": "^2.2.0",
@@ -32,6 +33,9 @@
     "eslint": "^9",
     "eslint-config-next": "15.5.2",
     "tailwindcss": "^4",
-    "typescript": "^5"
+    "typescript": "^5",
+    "vitest": "^1.6.0",
+    "@testing-library/react": "^15.0.0",
+    "jsdom": "^24.0.0"
   }
 }

--- a/src/app/collections/[slug]/ClientView.tsx
+++ b/src/app/collections/[slug]/ClientView.tsx
@@ -62,7 +62,9 @@ export default function ClientView({ slug, pageIdx }: { slug: string; pageIdx: n
 
         const token =
           typeof window !== "undefined" ? sessionStorage.getItem("accessToken") : null;
-        const headers = token ? { Authorization: `Bearer ${token}` } : {};
+        const headers: HeadersInit = token
+          ? { Authorization: `Bearer ${token}` }
+          : {};
 
         const theme = THEME_BY_SLUG[slug];
 

--- a/src/app/providers.test.tsx
+++ b/src/app/providers.test.tsx
@@ -1,0 +1,65 @@
+import React from "react";
+import { render, waitFor } from "@testing-library/react";
+import { useQuery, useMutation } from "@tanstack/react-query";
+import { AxiosError } from "axios";
+import { describe, test, expect, vi, beforeEach } from "vitest";
+
+const pushMock = vi.fn();
+vi.mock("../components/ui/toast", () => ({
+  useToast: () => ({ push: pushMock }),
+  ToastProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+import Providers from "./providers";
+
+describe("Providers QueryClient error handling", () => {
+  beforeEach(() => pushMock.mockReset());
+
+  test("pushes toast on query error with AxiosError message", async () => {
+    function QueryErr() {
+      const err = new AxiosError(
+        "oops",
+        undefined,
+        { headers: {} },
+        undefined,
+        { data: { message: "axios fail" }, status: 400, statusText: "", headers: {}, config: {} }
+      );
+      useQuery({ queryKey: ["q"], queryFn: async () => { throw err; } });
+      return null;
+    }
+    render(
+      <Providers>
+        <QueryErr />
+      </Providers>
+    );
+    await waitFor(() =>
+      expect(pushMock).toHaveBeenCalledWith(
+        expect.objectContaining({ description: "axios fail" })
+      )
+    );
+  });
+
+  test("pushes toast on mutation error", async () => {
+    function MutationErr() {
+      const mutation = useMutation({
+        mutationFn: async () => {
+          throw new Error("mutation fail");
+        },
+      });
+      React.useEffect(() => {
+        mutation.mutate();
+      }, [mutation]);
+      return null;
+    }
+    render(
+      <Providers>
+        <MutationErr />
+      </Providers>
+    );
+    await waitFor(() =>
+      expect(pushMock).toHaveBeenCalledWith(
+        expect.objectContaining({ description: "mutation fail" })
+      )
+    );
+  });
+});

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -1,24 +1,60 @@
 "use client";
 import { ThemeProvider } from "@primer/react";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+    MutationCache,
+    QueryCache,
+    QueryClient,
+    QueryClientProvider,
+} from "@tanstack/react-query";
 import React from "react";
-import { ToastProvider } from "@/components/ui/toast";
+import { ToastProvider, useToast } from "@/components/ui/toast";
+import { AxiosError } from "axios";
 
-export default function Providers({ children }: { children: React.ReactNode }) {
+function getErrorMessage(err: unknown): string {
+    if (err instanceof AxiosError) {
+        const data = err.response?.data as { message?: string } | undefined;
+        return data?.message ?? err.message;
+    }
+    if (err instanceof Error) return err.message;
+    return String(err);
+}
+
+function QueryClientWithToasts({ children }: { children: React.ReactNode }) {
+    const { push } = useToast();
     const [client] = React.useState(
         () =>
             new QueryClient({
+                queryCache: new QueryCache({
+                    onError: (error) =>
+                        push({
+                            type: "error",
+                            title: "Hata",
+                            description: getErrorMessage(error),
+                        }),
+                }),
+                mutationCache: new MutationCache({
+                    onError: (error) =>
+                        push({
+                            type: "error",
+                            title: "Hata",
+                            description: getErrorMessage(error),
+                        }),
+                }),
                 defaultOptions: {
                     queries: { refetchOnWindowFocus: false, retry: 1 },
                     mutations: { retry: 0 },
                 },
             })
     );
+    return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+
+export default function Providers({ children }: { children: React.ReactNode }) {
     return (
         <ThemeProvider colorMode="auto">
-            <QueryClientProvider client={client}>
-                <ToastProvider>{children}</ToastProvider>
-            </QueryClientProvider>
+            <ToastProvider>
+                <QueryClientWithToasts>{children}</QueryClientWithToasts>
+            </ToastProvider>
         </ThemeProvider>
     );
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "jsdom",
+    globals: true,
+  },
+  esbuild: {
+    jsx: "automatic",
+  },
+});


### PR DESCRIPTION
## Summary
- send toast messages for query and mutation errors via QueryClient
- cover Axios and generic errors with unit tests
- configure vitest and testing tools
- align testing-library with React 19 and fix ClientView headers typing

## Testing
- `npm install` *(fails: 403 Forbidden fetching @testing-library/react)*
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*


------
https://chatgpt.com/codex/tasks/task_e_68bc3c4d56f8832ea2bf7c7f0a2e245d