### PR TITLE
Fix login guard not detecting auth state

### DIFF
--- a/src/lib/auth/store.ts
+++ b/src/lib/auth/store.ts
@@ -57,6 +57,6 @@ export const useAuthStore = create<AuthState>((set, get) => ({
   },
   isAuthed: () => {
     if (typeof window === "undefined") return false;
-    return !!getCookie("accessToken");
+    return !!get().accessToken;
   },
 }));


### PR DESCRIPTION
## Summary
- ensure login guard checks auth state from store instead of cookies

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_68bc9cf87a0c832eaf7473827285659b