### PR TITLE
fix: load access token from cookie

### DIFF
--- a/src/lib/queries/profile.ts
+++ b/src/lib/queries/profile.ts
@@ -32,7 +32,10 @@ export const qk = {
 
 function useAccessToken() {
     const [t, setT] = React.useState<string | null>(null);
-    React.useEffect(() => setT(sessionStorage.getItem("accessToken")), []);
+    React.useEffect(() => {
+        const match = document.cookie.match(/(?:^|; )accessToken=([^;]*)/);
+        setT(match ? decodeURIComponent(match[1]) : null);
+    }, []);
     return t;
 }
 


### PR DESCRIPTION
## Summary
- read access token from cookies for profile queries

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*


------
https://chatgpt.com/codex/tasks/task_e_68bca118a8ac832ea40118c9033d6cd4