### PR TITLE
Fix client token handling for profile and sell pages

### DIFF
--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -13,8 +13,12 @@ export async function POST(req: NextRequest) {
   const data = await r.json();
   const res = NextResponse.json(data, { status: r.status });
   if (r.ok) {
+    // Make accessToken readable by the client so that Axios can attach it
+    // to the Authorization header on subsequent requests. Keeping it
+    // non-HttpOnly allows hooks like `useMyProfile` and the sell page to
+    // access the token via `document.cookie`.
     res.cookies.set("accessToken", data.accessToken, {
-      httpOnly: true,
+      httpOnly: false,
       sameSite: "lax",
       path: "/",
     });

--- a/src/app/api/auth/refresh/route.ts
+++ b/src/app/api/auth/refresh/route.ts
@@ -15,8 +15,10 @@ export async function POST(req: NextRequest) {
   const data = await r.json();
   const res = NextResponse.json(data, { status: r.status });
   if (r.ok) {
+    // Expose the new access token to the client so Axios can pick it up
+    // and refresh authenticated requests without requiring a page reload.
     res.cookies.set("accessToken", data.accessToken, {
-      httpOnly: true,
+      httpOnly: false,
       sameSite: "lax",
       path: "/",
     });

--- a/src/app/sell/page.tsx
+++ b/src/app/sell/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useState, ChangeEvent, FormEvent } from "react";
 import { useRouter } from "next/navigation";
 import { CheckCircleIcon, ExclamationTriangleIcon } from "@heroicons/react/24/solid";
 import Guard from "@/components/auth/Guard";
+import { useAuthStore } from "@/lib/auth/store";
 
 const API_BASE = process.env.NEXT_PUBLIC_API_BASE ?? "http://localhost:8080";
 
@@ -53,6 +54,7 @@ function Note({ children }: { children: React.ReactNode }) {
 /* ==== Page ==== */
 export default function SellPage() {
   const router = useRouter();
+  const accessToken = useAuthStore((s) => s.accessToken);
 
   const [brands, setBrands] = useState<Brand[]>([]);
   const [series, setSeries] = useState<Series[]>([]);
@@ -93,11 +95,9 @@ export default function SellPage() {
         setLoadingInit(true);
         setErrorInit(null);
 
-        const token =
-          typeof window !== "undefined" ? sessionStorage.getItem("accessToken") : null;
         const headers: Record<string, string> = {};
-        if (token) {
-          headers.Authorization = `Bearer ${token}`;
+        if (accessToken) {
+          headers.Authorization = `Bearer ${accessToken}`;
         }
 
         const [bRes, tRes] = await Promise.all([
@@ -122,7 +122,7 @@ export default function SellPage() {
     return () => {
       cancel = true;
     };
-  }, []);
+  }, [accessToken]);
 
   /* ==== Dependent: series by brand ==== */
   useEffect(() => {
@@ -135,11 +135,9 @@ export default function SellPage() {
     }
     async function loadSeries() {
       try {
-        const token =
-          typeof window !== "undefined" ? sessionStorage.getItem("accessToken") : null;
         const headers: Record<string, string> = {};
-        if (token) {
-          headers.Authorization = `Bearer ${token}`;
+        if (accessToken) {
+          headers.Authorization = `Bearer ${accessToken}`;
         }
 
         const res = await fetch(
@@ -163,7 +161,7 @@ export default function SellPage() {
     return () => {
       cancel = true;
     };
-  }, [form.brandId]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [form.brandId, accessToken]); // eslint-disable-line react-hooks/exhaustive-deps
 
   /* ==== Handlers ==== */
   const onText =


### PR DESCRIPTION
## Summary
- Expose access token in auth API routes so client code can attach it to requests
- Use auth store instead of sessionStorage in sell page to send authorized requests

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_68bca55adf18832eb66521ec86dd0c2c