### PR TITLE
Fix auctions fetch to return content array

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -22,7 +22,8 @@ async function getLatestAuctions() {
         `${API_BASE}/api/v1/auctions?size=4&sortBy=createdAt&sortDir=DESC`,
         { cache: "no-store" }
     );
-    return (await r.json()) ?? [];
+    const data = await r.json();
+    return data?.content ?? [];
 }
 
 export default async function HomePage() {


### PR DESCRIPTION
## Summary
- parse auctions API response and return `content` array

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*
- `npm ci` *(fails: 403 Forbidden for package zustand)*

------
https://chatgpt.com/codex/tasks/task_e_68bd2de724e0832e9ca4c73c90e69999