### PR TITLE
Limit homepage 'Yeni Gelen Mezatlar' to four latest auctions

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -23,7 +23,7 @@ async function getLatestAuctions() {
         { cache: "no-store" }
     );
     const data = await r.json();
-    return data?.content ?? [];
+    return (data?.content ?? []).slice(0, 4);
 }
 
 export default async function HomePage() {


### PR DESCRIPTION
## Summary
- limit fetched auctions to four items so only the newest four appear in the "Yeni Gelen Mezatlar" section

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_68bd30b4be18832e8a00f575b4fa11c5