### PR TITLE
feat: show user's auctions on profile page

### DIFF
--- a/src/app/me/page.tsx
+++ b/src/app/me/page.tsx
@@ -11,6 +11,7 @@ import PrefsForm from "@/components/me/PrefsForm";
 import NotificationsForm from "@/components/me/NotificationsForm";
 import MyStats from "@/components/me/MyStats";
 import MyListingsGrid from "@/components/me/MyListingsGrid";
+import MyAuctionsGrid from "@/components/me/MyAuctionsGrid";
 
 export default function MePage() {
     const { data, isLoading, isError } = useMyProfile();
@@ -84,6 +85,12 @@ export default function MePage() {
                     <section className="rounded-2xl border border-neutral-800 bg-neutral-900/60 shadow-sm p-6">
                         <h2 className="text-xl font-semibold mb-4">İlanlarım</h2>
                         <MyListingsGrid me={me} />
+                    </section>
+
+                    {/* Mezatlarım */}
+                    <section className="rounded-2xl border border-neutral-800 bg-neutral-900/60 shadow-sm p-6">
+                        <h2 className="text-xl font-semibold mb-4">Mezatlarım</h2>
+                        <MyAuctionsGrid me={me} />
                     </section>
                 </div>
 

--- a/src/components/me/MyAuctionsGrid.tsx
+++ b/src/components/me/MyAuctionsGrid.tsx
@@ -1,0 +1,36 @@
+import AuctionCard from "@/components/auction/AuctionCard";
+import type { ProfileOwnerDto } from "@/lib/types/profile";
+import Link from "next/link";
+
+export default function MyAuctionsGrid({ me }: { me: ProfileOwnerDto }) {
+    const items = me.auctions ?? [];
+    if (!items.length) {
+        if (!me.listings?.length) {
+            return (
+                <div className="text-sm text-neutral-400">
+                    <p>Henüz mezat yok.</p>
+                    <div className="mt-2 flex gap-3 text-sm">
+                        <Link href="/sell" className="text-sky-400 hover:underline">
+                            İlan Oluştur
+                        </Link>
+                        <Link href="/auctions/new" className="text-sky-400 hover:underline">
+                            Mezat Oluştur
+                        </Link>
+                    </div>
+                </div>
+            );
+        }
+        return <p className="text-sm text-neutral-400">Henüz mezat yok.</p>;
+    }
+
+    return (
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+            {items.map((a) => (
+                <div key={a.id}>
+                    <AuctionCard a={a} />
+                </div>
+            ))}
+        </div>
+    );
+}
+

--- a/src/lib/types/profile.ts
+++ b/src/lib/types/profile.ts
@@ -1,4 +1,5 @@
 import type { ListingResponseDto } from "./listing";
+import type { AuctionListItemDto } from "./auction";
 
 export type DigestFrequency = "DAILY" | "WEEKLY" | "MONTHLY" | "NEVER" | string;
 export type ProfileLinkType = "INSTAGRAM" | "TWITTER" | "WEBSITE" | string;
@@ -73,6 +74,7 @@ export interface ProfileOwnerDto extends ProfilePublicDto {
     followersCount?: number;
     followingCount?: number;
     listings?: ListingResponseDto[];
+    auctions?: AuctionListItemDto[];
 }
 
 export interface ProfileUpdateRequest {


### PR DESCRIPTION
## Summary
- show user's auctions in new 'Mezatlarım' section
- allow creating listings or auctions when user has none
- extend profile types with `auctions` list

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*


------
https://chatgpt.com/codex/tasks/task_e_68bd64775ccc832e84becbf4119d6f8c