### PR TITLE
feat: list user auctions

### DIFF
--- a/src/components/me/MyAuctionsGrid.tsx
+++ b/src/components/me/MyAuctionsGrid.tsx
@@ -1,9 +1,20 @@
 import AuctionCard from "@/components/auction/AuctionCard";
+import { useAuctionsBySeller } from "@/lib/queries/auction";
 import type { ProfileOwnerDto } from "@/lib/types/profile";
 import Link from "next/link";
 
 export default function MyAuctionsGrid({ me }: { me: ProfileOwnerDto }) {
-    const items = me.auctions ?? [];
+    const { data, isLoading, isError } = useAuctionsBySeller();
+    const items = data ?? [];
+
+    if (isLoading) {
+        return <p className="text-sm text-neutral-400">Yükleniyor…</p>;
+    }
+
+    if (isError) {
+        return <p className="text-sm text-red-400">Mezatlar alınamadı.</p>;
+    }
+
     if (!items.length) {
         if (!me.listings?.length) {
             return (

--- a/src/lib/queries/auction.ts
+++ b/src/lib/queries/auction.ts
@@ -17,6 +17,13 @@ export const useAuctions = (params?: Record<string, unknown>) =>
     queryFn: async () => (await api.get("/api/v1/auctions", { params })).data,
   });
 
+export const useAuctionsBySeller = (userId?: number) =>
+  useQuery<AuctionListItemDto[]>({
+    queryKey: ["auctions", "seller", userId ?? "me"],
+    queryFn: async () =>
+      (await api.get("/api/v1/auctions/seller", { params: userId ? { userId } : undefined })).data,
+  });
+
 export const useAuction = (id: number) =>
   useQuery<AuctionResponseDto>({
     queryKey: ["auction", id],

--- a/src/lib/types/auction.ts
+++ b/src/lib/types/auction.ts
@@ -15,6 +15,7 @@ export type AuctionListItemDto = {
   endsAt: string;              // ISO
   // opsiyonel görsel
   coverUrl?: string | null;
+  sellerUserId?: number;
   sellerUsername?: string | null;
 };
 


### PR DESCRIPTION
## Summary
- support seller ids on auctions
- fetch auctions by seller and display on profile page

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc' and npm install blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68bd7534eed0832ea30a08d93bf112c8