### PR TITLE
Show seller usernames and enable profile auction editing

### DIFF
--- a/src/app/auctions/[id]/page.tsx
+++ b/src/app/auctions/[id]/page.tsx
@@ -2,6 +2,7 @@
 import Link from "next/link";
 import { useParams } from "next/navigation";
 import { useAuction, useBids, usePlaceBid } from "@/lib/queries/auction";
+import { useMyProfile } from "@/lib/queries/profile";
 import { formatCountdown, formatDateTime } from "@/lib/utils/time";
 import { trAuctionStatus } from "@/lib/utils/i18n";
 import { useMemo, useState } from "react";
@@ -25,6 +26,7 @@ export default function AuctionDetailPage() {
   }
   const { data: auction } = useAuction(id);
   const { data: bids } = useBids(id);
+  const { data: me } = useMyProfile();
   const mBid = usePlaceBid(id);
 
   const minNext = useMemo(() => {
@@ -89,6 +91,17 @@ export default function AuctionDetailPage() {
         <div className="lg:col-span-2 grid gap-3">
           <h1 className="text-2xl font-extrabold">{auction.title ?? `Mezat #${auction.id}`}</h1>
           <p className="text-sm text-neutral-400">{auction.description ?? "Açıklama bulunmuyor."}</p>
+          {auction.seller?.username && (
+            <div className="text-sm text-neutral-400">
+              Satıcı:{" "}
+              <Link
+                href={me?.username === auction.seller.username ? "/me" : `/u/${auction.seller.username}`}
+                className="text-sky-400 hover:underline"
+              >
+                @{auction.seller.username}
+              </Link>
+            </div>
+          )}
           <div className="grid grid-cols-2 sm:grid-cols-3 gap-3 text-sm">
             <Info label="Marka" value={auction.brand ?? "-"} />
             <Info label="Model" value={auction.model ?? "-"} />

--- a/src/components/auction/AuctionCard.tsx
+++ b/src/components/auction/AuctionCard.tsx
@@ -11,6 +11,7 @@ export default function AuctionCard({ a }: { a: AuctionListItemDto }) {
   const cover = a.coverUrl ?? `https://picsum.photos/seed/auction${a.id}/1200/800`;
   const router = useRouter();
   const { data: me } = useMyProfile();
+  const sellerUsername = a.sellerUsername || a.seller?.username;
 
   return (
     <div>
@@ -45,24 +46,24 @@ export default function AuctionCard({ a }: { a: AuctionListItemDto }) {
               {highest === "-" ? "-" : `${Number(highest).toFixed(2)} ${a.currency}`}
             </span>
           </div>
-          {a.sellerUsername && (
+          {sellerUsername && (
             <div className="mt-2 text-xs text-neutral-400">
               Satıcı:{" "}
               <span
                 onClick={(e) => {
                   e.stopPropagation();
-                  const u = a.sellerUsername!;
+                  const u = sellerUsername!;
                   router.push(me?.username === u ? "/me" : `/u/${u}`);
                 }}
                 className="cursor-pointer text-sky-400 hover:underline"
               >
-                @{a.sellerUsername}
+                @{sellerUsername}
               </span>
             </div>
           )}
         </div>
       </Link>
-      {me?.username && me?.username === a.sellerUsername && (
+      {me && (me.username === sellerUsername || me.userId === a.sellerUserId) && (
         <div className="mt-2 flex justify-end gap-3 text-xs">
           <Link href={`/auctions/${a.id}/edit`} className="text-sky-400 hover:underline">Düzenle</Link>
         </div>

--- a/src/components/me/MyAuctionsGrid.tsx
+++ b/src/components/me/MyAuctionsGrid.tsx
@@ -35,7 +35,7 @@ export default function MyAuctionsGrid({ me }: { me: ProfileOwnerDto }) {
     }
 
     return (
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-5">
             {items.map((a) => (
                 <div key={a.id}>
                     <AuctionCard a={a} />

--- a/src/lib/types/auction.ts
+++ b/src/lib/types/auction.ts
@@ -17,6 +17,7 @@ export type AuctionListItemDto = {
   coverUrl?: string | null;
   sellerUserId?: number;
   sellerUsername?: string | null;
+  seller?: ProfileMini | null;
 };
 
 export type AuctionResponseDto = {


### PR DESCRIPTION
## Summary
- display seller username on auction cards and auction detail page
- allow owners to edit their auctions from profile
- enlarge my auctions cards for readability

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc' imported from eslint.config.mjs)*

------
https://chatgpt.com/codex/tasks/task_e_68bd785b4bdc832e8ebd83fe8f8b7035