### PR TITLE
Add edit button for auctions on profile page

### DIFF
--- a/src/components/auction/AuctionCard.tsx
+++ b/src/components/auction/AuctionCard.tsx
@@ -63,11 +63,6 @@ export default function AuctionCard({ a }: { a: AuctionListItemDto }) {
           )}
         </div>
       </Link>
-      {me && (me.username === sellerUsername || me.userId === a.sellerUserId) && (
-        <div className="mt-2 flex justify-end gap-3 text-xs">
-          <Link href={`/auctions/${a.id}/edit`} className="text-sky-400 hover:underline">Düzenle</Link>
-        </div>
-      )}
     </div>
   );
 }

--- a/src/components/me/MyAuctionsGrid.tsx
+++ b/src/components/me/MyAuctionsGrid.tsx
@@ -39,6 +39,11 @@ export default function MyAuctionsGrid({ me }: { me: ProfileOwnerDto }) {
             {items.map((a) => (
                 <div key={a.id}>
                     <AuctionCard a={a} />
+                    <div className="mt-2 flex items-center justify-end text-xs text-neutral-400">
+                        <Link href={`/auctions/${a.id}/edit`} className="hover:underline">
+                            Düzenle
+                        </Link>
+                    </div>
                 </div>
             ))}
         </div>


### PR DESCRIPTION
## Summary
- add edit link to each auction in profile's auction grid
- remove redundant edit link from auction card

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*
- `npm run build` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd7ed75800832eb8721b9a9a1df8f5