### PR TITLE
Fix follow lists and endpoints

### DIFF
--- a/src/components/profile/FollowList.tsx
+++ b/src/components/profile/FollowList.tsx
@@ -9,8 +9,8 @@ export function FollowersList({ username }: { username: string }) {
   if (isLoading) return <p className="text-sm text-neutral-400">Yükleniyor…</p>;
   if (isError) return <p className="text-sm text-red-400">Takipçiler alınamadı.</p>;
 
-  if (!data?.content?.length) return <p className="text-sm text-neutral-400">Takipçi yok.</p>;
-  return <UserList items={data.content} />;
+  if (!data?.items?.length) return <p className="text-sm text-neutral-400">Takipçi yok.</p>;
+  return <UserList items={data.items} />;
 }
 
 export function FollowingList({ username }: { username: string }) {
@@ -18,8 +18,8 @@ export function FollowingList({ username }: { username: string }) {
   if (isLoading) return <p className="text-sm text-neutral-400">Yükleniyor…</p>;
   if (isError) return <p className="text-sm text-red-400">Takip edilenler alınamadı.</p>;
 
-  if (!data?.content?.length) return <p className="text-sm text-neutral-400">Kimseyi takip etmiyorsun.</p>;
-  return <UserList items={data.content} />;
+  if (!data?.items?.length) return <p className="text-sm text-neutral-400">Kimseyi takip etmiyorsun.</p>;
+  return <UserList items={data.items} />;
 }
 
 function UserList({ items }: { items: {username:string;displayName?:string|null;avatarUrl?:string|null;isVerified?:boolean|null}[] }) {

--- a/src/lib/queries/follow.ts
+++ b/src/lib/queries/follow.ts
@@ -1,40 +1,68 @@
 import api from "@/lib/api";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { qk } from "@/lib/queries/profile";
 
-export type FollowUser = { username: string; displayName?: string | null; avatarUrl?: string | null; isVerified?: boolean | null; };
-export type FollowPage = { content: FollowUser[]; page: number; size: number; totalElements: number; totalPages: number; last: boolean; };
+export type FollowUser = {
+  username: string;
+  displayName?: string | null;
+  avatarUrl?: string | null;
+  isVerified?: boolean | null;
+};
+export type FollowPage = {
+  items: FollowUser[];
+  page: number;
+  size: number;
+  totalElements: number;
+  totalPages: number;
+};
 
-export function useFollowers(username: string, page=0, size=20) {
+export function useFollowers(username: string, page = 0, size = 20) {
   return useQuery<FollowPage>({
     queryKey: ["followers", username, page, size],
-    queryFn: async () => (await api.get(`/api/v1/profiles/${username}/followers`, { params: { page, size } })).data,
+    queryFn: async () =>
+      (
+        await api.get(`/api/v1/profiles/${username}/followers`, {
+          params: { page, size },
+        })
+      ).data,
     enabled: !!username,
   });
 }
-export function useFollowing(username: string, page=0, size=20) {
+export function useFollowing(username: string, page = 0, size = 20) {
   return useQuery<FollowPage>({
     queryKey: ["following", username, page, size],
-    queryFn: async () => (await api.get(`/api/v1/profiles/${username}/following`, { params: { page, size } })).data,
+    queryFn: async () =>
+      (
+        await api.get(`/api/v1/profiles/${username}/following`, {
+          params: { page, size },
+        })
+      ).data,
     enabled: !!username,
   });
 }
 export function useFollow(username: string) {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: async () => (await api.post(`/api/v1/follows/${username}`)).data,
+    mutationFn: async () =>
+      (await api.post(`/api/v1/profiles/${username}/follow`)).data,
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ["followers", username] });
       qc.invalidateQueries({ queryKey: ["following"] });
+      qc.invalidateQueries({ queryKey: qk.me });
+      qc.invalidateQueries({ queryKey: qk.public(username) });
     },
   });
 }
 export function useUnfollow(username: string) {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: async () => (await api.delete(`/api/v1/follows/${username}`)).data,
+    mutationFn: async () =>
+      (await api.delete(`/api/v1/profiles/${username}/follow`)).data,
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ["followers", username] });
       qc.invalidateQueries({ queryKey: ["following"] });
+      qc.invalidateQueries({ queryKey: qk.me });
+      qc.invalidateQueries({ queryKey: qk.public(username) });
     },
   });
 }


### PR DESCRIPTION
## Summary
- switch to follow API endpoints under `/api/v1/profiles/{username}/follow`
- read follower/following lists from `items` field instead of `content`
- invalidate profile queries so follow counts update immediately

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*


------
https://chatgpt.com/codex/tasks/task_e_68bd85094ad8832e963cf575b5c5f0c1