### PR TITLE
Show seller info on auctions

### DIFF
--- a/src/app/auctions/[id]/page.tsx
+++ b/src/app/auctions/[id]/page.tsx
@@ -39,16 +39,17 @@ export default function AuctionDetailPage() {
     const inc = () => setAmount((v) => (v || minNext) + 10);
     const dec = () => setAmount((v) => Math.max(minNext, (v || minNext) - 10));
 
-    const imgs = (
-      auction?.images?.length
-        ? [...auction.images]
-        : [{ url: `https://picsum.photos/seed/au${id}/1600/900`, idx: 0 }]
-    ).sort((a, b) => a.idx - b.idx);
-    const [imgIdx, setImgIdx] = useState(0);
-    const prevImg = () => setImgIdx((i) => (i - 1 + imgs.length) % imgs.length);
-    const nextImg = () => setImgIdx((i) => (i + 1) % imgs.length);
+  const imgs = (
+    auction?.images?.length
+      ? [...auction.images]
+      : [{ url: `https://picsum.photos/seed/au${id}/1600/900`, idx: 0 }]
+  ).sort((a, b) => a.idx - b.idx);
+  const [imgIdx, setImgIdx] = useState(0);
+  const prevImg = () => setImgIdx((i) => (i - 1 + imgs.length) % imgs.length);
+  const nextImg = () => setImgIdx((i) => (i + 1) % imgs.length);
 
-    if (!auction) return null;
+  if (!auction) return null;
+  const sellerUsername = auction.seller?.username ?? auction.sellerUsername;
 
   const submit = () => {
     const val = amount || minNext;
@@ -91,14 +92,14 @@ export default function AuctionDetailPage() {
         <div className="lg:col-span-2 grid gap-3">
           <h1 className="text-2xl font-extrabold">{auction.title ?? `Mezat #${auction.id}`}</h1>
           <p className="text-sm text-neutral-400">{auction.description ?? "Açıklama bulunmuyor."}</p>
-          {auction.seller?.username && (
+          {sellerUsername && (
             <div className="text-sm text-neutral-400">
               Satıcı:{" "}
               <Link
-                href={me?.username === auction.seller.username ? "/me" : `/u/${auction.seller.username}`}
+                href={me?.username === sellerUsername ? "/me" : `/u/${sellerUsername}`}
                 className="text-sky-400 hover:underline"
               >
-                @{auction.seller.username}
+                @{sellerUsername}
               </Link>
             </div>
           )}

--- a/src/lib/queries/auction.ts
+++ b/src/lib/queries/auction.ts
@@ -14,20 +14,34 @@ import type {
 export const useAuctions = (params?: Record<string, unknown>) =>
   useQuery<AuctionListItemDto[]>({
     queryKey: ["auctions", params],
-    queryFn: async () => (await api.get("/api/v1/auctions", { params })).data,
+    queryFn: async () =>
+      (
+        await api.get("/api/v1/auctions", {
+          params: { include: "seller", ...(params ?? {}) },
+        })
+      ).data,
   });
 
 export const useAuctionsBySeller = (userId?: number) =>
   useQuery<AuctionListItemDto[]>({
     queryKey: ["auctions", "seller", userId ?? "me"],
     queryFn: async () =>
-      (await api.get("/api/v1/auctions/seller", { params: userId ? { userId } : undefined })).data,
+      (
+        await api.get("/api/v1/auctions/seller", {
+          params: { include: "seller", ...(userId ? { userId } : {}) },
+        })
+      ).data,
   });
 
 export const useAuction = (id: number) =>
   useQuery<AuctionResponseDto>({
     queryKey: ["auction", id],
-    queryFn: async () => (await api.get(`/api/v1/auctions/${id}`)).data,
+    queryFn: async () =>
+      (
+        await api.get(`/api/v1/auctions/${id}`, {
+          params: { include: "seller" },
+        })
+      ).data,
     enabled: !!id,
   });
 

--- a/src/lib/types/auction.ts
+++ b/src/lib/types/auction.ts
@@ -23,6 +23,7 @@ export type AuctionListItemDto = {
 export type AuctionResponseDto = {
   id: number;
   sellerUserId: number;
+  sellerUsername?: string | null;
   listingId?: number | null;
   startPrice: string;
   currency: string;


### PR DESCRIPTION
## Summary
- Request seller data when fetching auction lists and details
- Include seller username in auction detail response type
- Render seller username on auction detail page

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*


------
https://chatgpt.com/codex/tasks/task_e_68bd9a718288832e98e3dca95d58b89f