### PR TITLE
feat: show seller username

### DIFF
--- a/src/app/auctions/[id]/page.tsx
+++ b/src/app/auctions/[id]/page.tsx
@@ -91,7 +91,6 @@ export default function AuctionDetailPage() {
       <section className="grid grid-cols-1 lg:grid-cols-3 gap-6">
         <div className="lg:col-span-2 grid gap-3">
           <h1 className="text-2xl font-extrabold">{auction.title ?? `Mezat #${auction.id}`}</h1>
-          <p className="text-sm text-neutral-400">{auction.description ?? "Açıklama bulunmuyor."}</p>
           {sellerUsername && (
             <div className="text-sm text-neutral-400">
               Satıcı:{" "}
@@ -103,6 +102,7 @@ export default function AuctionDetailPage() {
               </Link>
             </div>
           )}
+          <p className="text-sm text-neutral-400">{auction.description ?? "Açıklama bulunmuyor."}</p>
           <div className="grid grid-cols-2 sm:grid-cols-3 gap-3 text-sm">
             <Info label="Marka" value={auction.brand ?? "-"} />
             <Info label="Model" value={auction.model ?? "-"} />

--- a/src/components/auction/AuctionCard.tsx
+++ b/src/components/auction/AuctionCard.tsx
@@ -14,55 +14,50 @@ export default function AuctionCard({ a }: { a: AuctionListItemDto }) {
   const sellerUsername = a.sellerUsername || a.seller?.username;
 
   return (
-    <div>
-      <Link
-        href={`/auctions/${a.id}`}
-        className="group overflow-hidden rounded-2xl border border-white/10 bg-neutral-900 shadow-sm hover:shadow-md transition-shadow"
-      >
-        <div className="relative">
-          <img
-            src={cover}
-            alt={`auction-${a.id}`}
-            className="h-56 w-full object-cover transition-transform duration-300 group-hover:scale-[1.02]"
-          />
-          {/* Üst şerit: Kalan süre */}
-          <span className="absolute top-3 left-3 rounded-md bg-black/70 px-2 py-1 text-xs font-semibold text-emerald-300 ring-1 ring-white/10">
-            {formatCountdown(a.endsAt)}
-          </span>
-          {/* Sağ üst: durum */}
-          <span className="absolute top-3 right-3 rounded-md bg-white/10 px-2 py-1 text-xs font-semibold ring-1 ring-white/10">
-            {trAuctionStatus(a.status)}
-          </span>
-        </div>
+    <div
+      onClick={() => router.push(`/auctions/${a.id}`)}
+      className="group overflow-hidden rounded-2xl border border-white/10 bg-neutral-900 shadow-sm hover:shadow-md transition-shadow cursor-pointer"
+    >
+      <div className="relative">
+        <img
+          src={cover}
+          alt={`auction-${a.id}`}
+          className="h-56 w-full object-cover transition-transform duration-300 group-hover:scale-[1.02]"
+        />
+        {/* Üst şerit: Kalan süre */}
+        <span className="absolute top-3 left-3 rounded-md bg-black/70 px-2 py-1 text-xs font-semibold text-emerald-300 ring-1 ring-white/10">
+          {formatCountdown(a.endsAt)}
+        </span>
+        {/* Sağ üst: durum */}
+        <span className="absolute top-3 right-3 rounded-md bg-white/10 px-2 py-1 text-xs font-semibold ring-1 ring-white/10">
+          {trAuctionStatus(a.status)}
+        </span>
+      </div>
 
-        <div className="p-4 grid gap-1 text-sm">
-          <div className="flex items-center justify-between">
-            <span className="text-neutral-400">Başlangıç</span>
-            <span className="font-bold">{Number(a.startPrice).toFixed(2)} {a.currency}</span>
-          </div>
-          <div className="flex items-center justify-between">
-            <span className="text-neutral-400">En yüksek</span>
-            <span className="font-bold">
-              {highest === "-" ? "-" : `${Number(highest).toFixed(2)} ${a.currency}`}
-            </span>
-          </div>
-          {sellerUsername && (
-            <div className="mt-2 text-xs text-neutral-400">
-              Satıcı:{" "}
-              <span
-                onClick={(e) => {
-                  e.stopPropagation();
-                  const u = sellerUsername!;
-                  router.push(me?.username === u ? "/me" : `/u/${u}`);
-                }}
-                className="cursor-pointer text-sky-400 hover:underline"
-              >
-                @{sellerUsername}
-              </span>
-            </div>
-          )}
+      <div className="p-4 grid gap-1 text-sm">
+        <div className="flex items-center justify-between">
+          <span className="text-neutral-400">Başlangıç</span>
+          <span className="font-bold">{Number(a.startPrice).toFixed(2)} {a.currency}</span>
         </div>
-      </Link>
+        <div className="flex items-center justify-between">
+          <span className="text-neutral-400">En yüksek</span>
+          <span className="font-bold">
+            {highest === "-" ? "-" : `${Number(highest).toFixed(2)} ${a.currency}`}
+          </span>
+        </div>
+        {sellerUsername && (
+          <div className="mt-2 text-xs text-neutral-400">
+            Satıcı:{" "}
+            <Link
+              href={me?.username === sellerUsername ? "/me" : `/u/${sellerUsername}`}
+              onClick={(e) => e.stopPropagation()}
+              className="text-sky-400 hover:underline"
+            >
+              @{sellerUsername}
+            </Link>
+          </div>
+        )}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- show seller username prominently on auction detail page
- allow viewing seller profile directly from auction cards

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*


------
https://chatgpt.com/codex/tasks/task_e_68bdbb64686c832e8f9d0450f5337080