### PR TITLE
Add search page and integrate header search form

### DIFF
--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { useSearchParams } from "next/navigation";
+import ListingCard from "@/components/listings/ListingCard";
+import { useListings } from "@/lib/queries/listings";
+
+export default function SearchPage() {
+    const searchParams = useSearchParams();
+    const q = searchParams.get("q") ?? "";
+    const { data, isLoading, isError } = useListings({ q });
+
+    return (
+        <main className="mx-auto w-full max-w-[1200px] px-4 py-6 space-y-6">
+            <header className="space-y-1">
+                <h1 className="text-3xl font-extrabold tracking-tight">Arama</h1>
+                {q && <p className="text-sm text-neutral-400">"{q}" için sonuçlar</p>}
+            </header>
+
+            {isLoading && <div className="text-neutral-400">Yükleniyor…</div>}
+            {isError && <div className="text-rose-400">Bir hata oluştu.</div>}
+
+            {!isLoading && !data?.content?.length && (
+                <div className="text-neutral-400">Hiç sonuç bulunamadı.</div>
+            )}
+
+            <div className="grid grid-cols-2 gap-4 md:grid-cols-3 lg:grid-cols-4">
+                {data?.content?.map((it) => (
+                    <ListingCard key={it.id} it={it} />
+                ))}
+            </div>
+        </main>
+    );
+}
+

--- a/src/components/layout/SiteHeader.tsx
+++ b/src/components/layout/SiteHeader.tsx
@@ -1,6 +1,7 @@
 "use client";
 import Link from "next/link";
 import { useState } from "react";
+import { useRouter } from "next/navigation";
 import {
     MagnifyingGlassIcon,
 } from "@heroicons/react/24/outline";
@@ -11,6 +12,8 @@ import NavAuth from "./NavAuth";
 export default function SiteHeader() {
     const isAuthed = useAuthStore((s) => s.isAuthed());
     const [showModal, setShowModal] = useState(false);
+    const [query, setQuery] = useState("");
+    const router = useRouter();
 
     const handleAuctionsClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
         if (!isAuthed) {
@@ -40,17 +43,25 @@ export default function SiteHeader() {
 
                     {/* Sağ aksiyonlar */}
                     <div className="flex items-center gap-3">
-                        <div
+                        <form
                             role="search"
+                            onSubmit={(e) => {
+                                e.preventDefault();
+                                if (query.trim()) {
+                                    router.push(`/search?q=${encodeURIComponent(query)}`);
+                                }
+                            }}
                             className="hidden sm:flex items-center gap-2 rounded-full border border-neutral-200 dark:border-white/10 px-3 py-1.5 bg-white/60 dark:bg-white/5"
                         >
                             <MagnifyingGlassIcon className="h-4 w-4 text-neutral-500 dark:text-neutral-400" aria-hidden />
                             <input
+                                value={query}
+                                onChange={(e) => setQuery(e.target.value)}
                                 placeholder="Modeller, markalar ara…"
                                 className="bg-transparent outline-none text-sm w-48 placeholder:text-neutral-400"
                                 aria-label="Arama"
                             />
-                        </div>
+                        </form>
                         <NavAuth />
                     </div>
                 </div>

--- a/src/lib/queries/listings.ts
+++ b/src/lib/queries/listings.ts
@@ -59,6 +59,7 @@ const toQuery = (p: ListingsSearchParams = {}) => {
     const arr = (k: string, v?: number[]) => v?.forEach(x => u.append(k, String(x)));
     const str = (k: string, v?: string | number | boolean) => (v !== undefined && v !== null && v !== "" ? u.set(k, String(v)) : null);
 
+    str("q", p.q);
     arr("brandIds", p.brandIds);
     arr("seriesIds", p.seriesIds);
     arr("tagIds", p.tagIds);


### PR DESCRIPTION
## Summary
- wire up header search box to stateful form and navigate on submit
- add search page that reads query string and lists matching listings
- pass `q` parameter through listing query utility

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc'; npm install 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c1c1823b20832eb055fe019801ae13