### PR TITLE
feat: add advanced listing filters

### DIFF
--- a/src/app/listings/page.tsx
+++ b/src/app/listings/page.tsx
@@ -14,10 +14,20 @@ export default function ListingsPage() {
     const page = data?.number ?? 0;
     const totalPages = data?.totalPages ?? 0;
 
-    const filters: Filters = useMemo(() => ({
-        type: params.type, priceMin: params.priceMin, priceMax: params.priceMax,
-        sortBy: params.sortBy, sortDir: params.sortDir, size: params.size
-    }), [params]);
+    const filters: Filters = useMemo(
+        () => ({
+            q: params.q,
+            brandIds: params.brandIds,
+            seriesIds: params.seriesIds,
+            type: params.type,
+            priceMin: params.priceMin,
+            priceMax: params.priceMax,
+            sortBy: params.sortBy,
+            sortDir: params.sortDir,
+            size: params.size,
+        }),
+        [params],
+    );
 
     return (
         <main className="mx-auto w-full max-w-[1200px] px-4 py-6 space-y-6">

--- a/src/components/listings/ListingFilters.tsx
+++ b/src/components/listings/ListingFilters.tsx
@@ -5,7 +5,16 @@ import type { ListingsSearchParams } from "@/lib/queries/listings";
 
 export type Filters = Pick<
   ListingsSearchParams,
-  "type" | "priceMin" | "priceMax" | "sortBy" | "sortDir" | "size"
+  |
+    "q"
+    | "brandIds"
+    | "seriesIds"
+    | "type"
+    | "priceMin"
+    | "priceMax"
+    | "sortBy"
+    | "sortDir"
+    | "size"
 >;
 
 interface ListingFiltersProps {
@@ -23,6 +32,52 @@ export default function ListingFilters({
 
   return (
     <div className="grid gap-3 rounded-xl border border-white/10 bg-neutral-900 p-3 sm:grid-cols-3 lg:grid-cols-6">
+      <input
+        type="text"
+        placeholder="Ara"
+        value={local.q ?? ""}
+        onChange={(e) =>
+          setLocal({ ...local, q: e.target.value || undefined })
+        }
+        className="input"
+      />
+
+      <input
+        type="text"
+        placeholder="Marka ID'leri (virgülle)"
+        value={local.brandIds?.join(",") ?? ""}
+        onChange={(e) =>
+          setLocal({
+            ...local,
+            brandIds: e.target.value
+              ? e.target.value
+                  .split(",")
+                  .map((x) => Number(x.trim()))
+                  .filter((n) => !Number.isNaN(n))
+              : undefined,
+          })
+        }
+        className="input"
+      />
+
+      <input
+        type="text"
+        placeholder="Seri ID'leri (virgülle)"
+        value={local.seriesIds?.join(",") ?? ""}
+        onChange={(e) =>
+          setLocal({
+            ...local,
+            seriesIds: e.target.value
+              ? e.target.value
+                  .split(",")
+                  .map((x) => Number(x.trim()))
+                  .filter((n) => !Number.isNaN(n))
+              : undefined,
+          })
+        }
+        className="input"
+      />
+
       <select
         value={local.type ?? ""}
         onChange={(e) =>
@@ -108,6 +163,9 @@ export default function ListingFilters({
         <button
           onClick={() => {
             const reset: Filters = {
+              q: undefined,
+              brandIds: undefined,
+              seriesIds: undefined,
               type: undefined,
               priceMin: undefined,
               priceMax: undefined,

--- a/src/lib/queries/listings.ts
+++ b/src/lib/queries/listings.ts
@@ -59,6 +59,7 @@ const toQuery = (p: ListingsSearchParams = {}) => {
     const arr = (k: string, v?: number[]) => v?.forEach(x => u.append(k, String(x)));
     const str = (k: string, v?: string | number | boolean) => (v !== undefined && v !== null && v !== "" ? u.set(k, String(v)) : null);
 
+    str("q", p.q);
     arr("brandIds", p.brandIds);
     arr("seriesIds", p.seriesIds);
     arr("tagIds", p.tagIds);


### PR DESCRIPTION
## Summary
- add UI fields for text search, brand IDs, and series IDs
- propagate new filter values into listings page state
- support query string generation for text search

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*


------
https://chatgpt.com/codex/tasks/task_e_68c1c18da41c832ea44a4da80fa72e54