### PR TITLE
feat: add theme switching

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "axios": "^1.11.0",
     "clsx": "^2.1.1",
     "next": "15.5.2",
+    "next-themes": "^0.2.1",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "styled-components": "^5.3.11",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,18 +3,21 @@ import type { Metadata } from "next";
 import Providers from "./providers";
 import SiteHeader from "@/components/layout/SiteHeader";
 import Footer from "@/components/layout/Footer";
+import { ThemeProvider } from "next-themes";
 
 export const metadata: Metadata = { title: "GarageMint" };
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="tr" className="h-full">
-      <body className="min-h-screen h-full flex flex-col bg-neutral-950 text-neutral-100">
-        <Providers>
-          <SiteHeader />
-          <main className="flex-1">{children}</main>
-          <Footer />
-        </Providers>
+    <html lang="tr" className="h-full" suppressHydrationWarning>
+      <body className="min-h-screen h-full flex flex-col bg-white text-neutral-900 dark:bg-neutral-950 dark:text-neutral-100">
+        <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
+          <Providers>
+            <SiteHeader />
+            <main className="flex-1">{children}</main>
+            <Footer />
+          </Providers>
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -1,6 +1,6 @@
 
- "use client";
- import { ThemeProvider } from "@primer/react";
+"use client";
+import { ThemeProvider as PrimerThemeProvider } from "@primer/react";
 import {
     MutationCache,
     QueryCache,
@@ -9,6 +9,7 @@ import {
 } from "@tanstack/react-query";
  import React from "react";
 import { ToastProvider, useToast } from "@/components/ui/toast";
+import { useTheme } from "next-themes";
 import { AxiosError } from "axios";
  
 function getErrorMessage(err: unknown): string {
@@ -51,11 +52,13 @@ function QueryClientWithToasts({ children }: { children: React.ReactNode }) {
 }
 
 export default function Providers({ children }: { children: React.ReactNode }) {
-     return (
-         <ThemeProvider colorMode="auto">
+    const { resolvedTheme } = useTheme();
+    const colorMode = resolvedTheme === "dark" ? "night" : resolvedTheme === "light" ? "day" : "auto";
+    return (
+        <PrimerThemeProvider colorMode={colorMode}>
             <ToastProvider>
                 <QueryClientWithToasts>{children}</QueryClientWithToasts>
             </ToastProvider>
-         </ThemeProvider>
-     );
- }
+        </PrimerThemeProvider>
+    );
+}

--- a/src/components/layout/SiteHeader.tsx
+++ b/src/components/layout/SiteHeader.tsx
@@ -1,9 +1,8 @@
 "use client";
 import Link from "next/link";
-import { useState } from "react";
-import {
-    MagnifyingGlassIcon,
-} from "@heroicons/react/24/outline";
+import { useEffect, useState } from "react";
+import { MagnifyingGlassIcon, MoonIcon, SunIcon } from "@heroicons/react/24/outline";
+import { useTheme } from "next-themes";
 import { useAuthStore } from "@/lib/auth/store";
 import SignupPromptModal from "@/components/auth/SignupPromptModal";
 import NavAuth from "./NavAuth";
@@ -11,6 +10,12 @@ import NavAuth from "./NavAuth";
 export default function SiteHeader() {
     const isAuthed = useAuthStore((s) => s.isAuthed());
     const [showModal, setShowModal] = useState(false);
+    const { theme, setTheme } = useTheme();
+    const [mounted, setMounted] = useState(false);
+
+    useEffect(() => setMounted(true), []);
+
+    const toggleTheme = () => setTheme(theme === "dark" ? "light" : "dark");
 
     const handleAuctionsClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
         if (!isAuthed) {
@@ -51,6 +56,17 @@ export default function SiteHeader() {
                                 aria-label="Arama"
                             />
                         </div>
+                        <button
+                            onClick={toggleTheme}
+                            className="rounded-full p-2 border border-neutral-200 dark:border-white/10 bg-white/60 dark:bg-white/5"
+                            aria-label="Temayı değiştir"
+                        >
+                            {mounted && (theme === "dark" ? (
+                                <SunIcon className="h-5 w-5" />
+                            ) : (
+                                <MoonIcon className="h-5 w-5" />
+                            ))}
+                        </button>
                         <NavAuth />
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
- add `next-themes` dependency and ThemeProvider wrapper
- sync Primer theme with selected light or dark mode
- add header button to toggle between light and dark themes

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*


------
https://chatgpt.com/codex/tasks/task_e_68c1c18e9950832e8b938dcdd4d16b10