### PR TITLE
fix: wrap next-themes provider in client component

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,7 +3,7 @@ import type { Metadata } from "next";
 import Providers from "./providers";
 import SiteHeader from "@/components/layout/SiteHeader";
 import Footer from "@/components/layout/Footer";
-import { ThemeProvider } from "next-themes";
+import AppThemeProvider from "./theme-provider";
 
 export const metadata: Metadata = { title: "GarageMint" };
 
@@ -11,13 +11,13 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang="tr" className="h-full" suppressHydrationWarning>
       <body className="min-h-screen h-full flex flex-col bg-white text-neutral-900 dark:bg-neutral-950 dark:text-neutral-100">
-        <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
+        <AppThemeProvider>
           <Providers>
             <SiteHeader />
             <main className="flex-1">{children}</main>
             <Footer />
           </Providers>
-        </ThemeProvider>
+        </AppThemeProvider>
       </body>
     </html>
   );

--- a/src/app/theme-provider.tsx
+++ b/src/app/theme-provider.tsx
@@ -1,0 +1,12 @@
+"use client";
+
+import * as React from "react";
+import { ThemeProvider } from "next-themes";
+
+export default function AppThemeProvider({ children }: { children: React.ReactNode }) {
+  return (
+    <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
+      {children}
+    </ThemeProvider>
+  );
+}


### PR DESCRIPTION
## Summary
- wrap next-themes provider in a client component and use it from the root layout

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*


------
https://chatgpt.com/codex/tasks/task_e_68c1c5548388832e972b6b71835eaec3