### PR TITLE
Use public logo image in header

### DIFF
--- a/public/logo.svg
+++ b/public/logo.svg
@@ -1,0 +1,9 @@
+<svg width="28" height="28" viewBox="0 0 28 28" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="28" height="28" rx="4" fill="url(#a)"/>
+  <defs>
+    <linearGradient id="a" x1="0" y1="0" x2="28" y2="28" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#38BDF8"/>
+      <stop offset="1" stop-color="#2563EB"/>
+    </linearGradient>
+  </defs>
+</svg>

--- a/src/components/layout/SiteHeader.tsx
+++ b/src/components/layout/SiteHeader.tsx
@@ -1,5 +1,6 @@
 "use client";
 import Link from "next/link";
+import Image from "next/image";
 import { useEffect, useState } from "react";
 import { MagnifyingGlassIcon, MoonIcon, SunIcon } from "@heroicons/react/24/outline";
 import { useTheme } from "next-themes";
@@ -30,7 +31,13 @@ export default function SiteHeader() {
                 <div className="mx-auto max-w-6xl px-4 py-3 flex items-center justify-between gap-4">
                     {/* Marka */}
                     <Link href="/" className="flex items-center gap-2" aria-label="Anasayfa">
-                        <div className="h-7 w-7 rounded-lg bg-gradient-to-br from-sky-400 to-blue-600 shadow-sm ring-1 ring-white/40 dark:ring-white/10" />
+                        <Image
+                            src="/logo.svg"
+                            alt="GarageMint logo"
+                            width={28}
+                            height={28}
+                            className="h-7 w-7 rounded-lg shadow-sm ring-1 ring-white/40 dark:ring-white/10"
+                        />
                         <span className="font-extrabold tracking-tight text-xl">GarageMint</span>
                     </Link>
 


### PR DESCRIPTION
## Summary
- show GarageMint logo from the `public` folder in the site header
- add gradient `logo.svg` asset

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc'; `npm install` blocked with 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c1d636180c832e9d8087ae5d2b7b58